### PR TITLE
Bug fix: Persistant room option on smartphones

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -188,25 +188,29 @@ $('#loadContentModal').on('shown.bs.modal', function (e) {
     });
     if (typeof $('#room_persistantRoom') !== 'undefined') {
         if ($('#room_persistantRoom').prop('checked')) {
-            $('#roomStartForm').collapse('hide')
+            $('#roomStartForm').collapse('hide');
+            $('#roomStartForm > div:first-of-type > input').removeAttr('required');
             if ($('#room_totalOpenRooms').prop('checked')){
                 $('#totalOpenRoomsOpenTime').collapse('show');
             } else {
                 $('#totalOpenRoomsOpenTime').collapse('hide');
             }
         } else {
+            $('#roomStartForm > div:first-of-type > input').prop('required',true);
             $('#roomStartForm').collapse('show');
             $('#totalOpenRoomsOpenTime').collapse('hide');
         }
         $('#room_persistantRoom').change(function () {
             if ($('#room_persistantRoom').prop('checked')) {
-                $('#roomStartForm').collapse('hide')
+                $('#roomStartForm').collapse('hide');
+                $('#roomStartForm > div:first-of-type > input').removeAttr('required');
                 if ($('#room_totalOpenRooms').prop('checked')){
                     $('#totalOpenRoomsOpenTime').collapse('show');
                 } else {
                     $('#totalOpenRoomsOpenTime').collapse('hide');
                 }
             } else {
+                $('#roomStartForm > div:first-of-type > input').prop('required',true);
                 $('#roomStartForm').collapse('show');
                 $('#totalOpenRoomsOpenTime').collapse('hide');
             }


### PR DESCRIPTION
Hi,

We have noticed that if you check the "This conference has no date and is permanently available" on a smartphone and then click the save button, nothing happens. This is caused by the "Start" input, that it is required always, and as it is empty by default, the form is not valid.

One way to work around this is by selecting any date and then checking the persistant room, but this is not what users do.

What we have done is fixing it on the Javascript. When you click on the persistant room check, we remove the required attribute from the Start input, and set it again if you uncheck the persistence, making the form submitable in any case.

Anyway, maybe there is a better approach to fix this, so feel free to suggest other fixes.

Best regards,
Obelisk