### PR TITLE
Fix modal server enterprise settings

### DIFF
--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -4,7 +4,7 @@
 ### Features:
 * **LookyLooky** The great new document sharing tool [LookyLooky GIthub Repo](https://github.com/H2-invent/lookylooky)
 * **New DDEV local development setup**
-* **New Design (improved)**
+* **New Design (improved.)**
 ### Bug Fixes:
 * remove header in sip trunk generation
 * fix ical reply

--- a/assets/css/layout/_black.scss
+++ b/assets/css/layout/_black.scss
@@ -224,6 +224,15 @@ label {
   }
 }
 
+// MDB forces a light disabled-background on read-only inputs via
+// `.form-outline .form-control[readonly]` (specificity 0,3,0), which overrides
+// the rule above. Override it so read-only inputs stay dark in dark mode.
+.form-control[readonly],
+.form-outline .form-control[readonly] {
+  background-color: $black_background !important;
+  color: $black_font-color !important;
+}
+
 .form-control:focus {
   background-color: $black_background_active;
   color: $black_font-color;

--- a/assets/css/layout/_main.scss
+++ b/assets/css/layout/_main.scss
@@ -1385,6 +1385,19 @@ a:hover {
   border-radius: 4px;
 }
 
+.form-control-color {
+  padding: 0;
+
+  &::-webkit-color-swatch {
+    border: none;
+    border-radius: 5px;
+  }
+
+  &::-moz-color-swatch {
+    border: none;
+    border-radius: 5px;
+  }
+}
 
 .btn-outline-white {
   border-color: white;

--- a/templates/form/ja_theme.html.twig
+++ b/templates/form/ja_theme.html.twig
@@ -46,3 +46,10 @@
 {% block password_widget %}
     {{ block('text_widget') }}
 {% endblock %}
+
+{# Color picker without the form-outline wrapper/border #}
+{% block color_widget %}
+    {% set type = type|default('color') %}
+    {% set attr = attr|merge({'class': (attr.class|default('') ~ ' form-control form-control-color')|trim}) %}
+    {{ block('form_widget_simple') }}
+{% endblock %}

--- a/templates/servers/__serverEnterpriseModal.html.twig
+++ b/templates/servers/__serverEnterpriseModal.html.twig
@@ -35,12 +35,12 @@
                                 Hier können Sie einen eigenen SMTP Server zum Versenden von Emails angeben. Wenn kein SMTP Server angegeben ist wird der Standard Server von jitsi-admin verwendet.
                             {% endtrans %}
                         </p>
-                        <div class="row">
+                        <div class="row align-items-end">
                             <div class="col-md-6">
                                 {{ form_row(form.smtpHost) }}
                             </div>
                             <div class="col-md-3">
-                                {{ form_row(form.smtpEncryption) }}
+                                {{ form_row(form.smtpEncryption, {'attr': {'class': 'form-select-lg'}}) }}
                             </div>
                             <div class="col-md-3">
                                 {{ form_row(form.smtpPort) }}


### PR DESCRIPTION
Fix modal server enterprise settings: dark-mode readonly input, SMTP field alignment and remove color picker wrapper