### PR TITLE
Fix: Doppelte Recording-API-Aufrufe

### DIFF
--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -3,6 +3,8 @@
 
 #### 🚀 Features:
 ### 🐛 Bug Fixes:
+* Fix duplicate recording API calls
+
 ### ⭐ Improvements:
 * Add lobby moderator permission flag to the JWT
 

--- a/assets/js/createSocialButtons.js
+++ b/assets/js/createSocialButtons.js
@@ -1,12 +1,7 @@
-import {setupStartEgress, setupStopEgress} from "./livekit/egress";
-
-
 var gDevices;
 export function initSocialIcons(cbFkt) {
     createSocialBox();
     createCameraChangeButton(cbFkt);
-    setupStartEgress();
-    setupStopEgress();
 }
 
 function createCameraChangeButton(cbFkt) {

--- a/assets/js/livekit/egress.js
+++ b/assets/js/livekit/egress.js
@@ -1,6 +1,10 @@
-const startEgress = document.querySelectorAll('.startEgress');
-const stopEgress = document.getElementById('stopEgress');
-let egressID = null;
+// Inits Click-Events and shows recording icons
+export function initRecording() {
+    setupStartEgress();
+    setupStopEgress();
+    document.getElementById('wrapper-recording').classList.remove('d-none');
+}
+
 // Click-Events für alle Elemente mit der Klasse 'startEgress'
 export function setupStartEgress() {
     const startRecordingButtons = document.querySelectorAll('.startEgress');

--- a/assets/js/livekit/livekitUtils.js
+++ b/assets/js/livekit/livekitUtils.js
@@ -5,6 +5,7 @@ import {enterMeeting, leaveMeeting} from "../websocket";
 import {initStartWhiteboard} from "../startWhiteboard";
 import {showPlayPause} from "../moderatorIframe";
 import {initStarSend} from "../endModal";
+import {initRecording} from "./egress";
 
 export class LivekitUtils {
     conferenceRunning = false;
@@ -27,8 +28,9 @@ export class LivekitUtils {
             enterMeeting();
             initStartWhiteboard();
             showPlayPause();
-            initSocialIcons(changeCamera.bind(this));
+            // initSocialIcons(changeCamera.bind(this));
             // this.initChatToggle();
+            initRecording();
             this.conferenceRunning = true;
             this.initMicAndCamera();
             window.onbeforeunload = function (e) {

--- a/templates/conference_modules/__livekit_recording.html.twig
+++ b/templates/conference_modules/__livekit_recording.html.twig
@@ -1,48 +1,46 @@
 {% if app.user and room.moderator == app.user and room.server.enableRecording %}
-<div id="startEgress" class="wrapper {% if getRecordingForRoomAndUser(app.user,room) %}d-none{% endif %}">
-    <div class="dropdown">
-        <div
-                class=" conference-icon"
-                type="button"
-                href="#"
-                id="startRecording"
-                data-mdb-dropdown-init
-                data-mdb-ripple-init
-                aria-expanded="false"
-        >
-            <i class="fa-solid fa-record-vinyl"></i>
+    <div id="wrapper-recording" class="d-none">
+        <div id="startEgress" class="wrapper {% if getRecordingForRoomAndUser(app.user,room) %}d-none{% endif %}">
+            <div class="dropdown">
+                <div
+                        class=" conference-icon"
+                        type="button"
+                        href="#"
+                        id="startRecording"
+                        data-mdb-dropdown-init
+                        data-mdb-ripple-init
+                        aria-expanded="false"
+                >
+                    <i class="fa-solid fa-record-vinyl"></i>
+                </div>
+                <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                    <li><a class="dropdown-item startEgress"
+                           href="{{ path('app_start_egress',{'template':'single-speaker','uidReal':room.uidReal}) }}">{{ 'recording.startSpeakerOnly'|trans }}</a>
+                    </li>
+                    <li><a class="dropdown-item startEgress"
+                           href="{{ path('app_start_egress',{'template':'speaker','uidReal':room.uidReal}) }}">{{ 'recording.startSpeaker'|trans }}</a>
+                    </li>
+                    <li><a class="dropdown-item startEgress"
+                           href="{{ path('app_start_egress',{'template':'grid','uidReal':room.uidReal}) }}">{{ 'recording.startGrid'|trans }}</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="wrapper-helper">
+                {{ 'options.startRecording'|trans }}
+            </div>
         </div>
-        <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-            <li><a class="dropdown-item startEgress"
-                   href="{{ path('app_start_egress',{'template':'single-speaker','uidReal':room.uidReal}) }}">{{ 'recording.startSpeakerOnly'|trans }}</a>
-            </li>
-            <li><a class="dropdown-item startEgress"
-                   href="{{ path('app_start_egress',{'template':'speaker','uidReal':room.uidReal}) }}">{{ 'recording.startSpeaker'|trans }}</a>
-            </li>
-            <li><a class="dropdown-item startEgress"
-                   href="{{ path('app_start_egress',{'template':'grid','uidReal':room.uidReal}) }}">{{ 'recording.startGrid'|trans }}</a>
-            </li>
-        </ul>
-    </div>
-    <div class="wrapper-helper">
-        {{ 'options.startRecording'|trans }}
-    </div>
 
-</div>
-
-<div class="wrapper {% if not getRecordingForRoomAndUser(app.user,room) %}d-none{% endif %}">
-    <div class=" conference-icon"
-         data-url="{{ path('app_stop_egress',{'recordingId':'egressId'}) }}"
-         data-egeressId="{% if getRecordingForRoomAndUser(app.user,room) %}{{ getRecordingForRoomAndUser(app.user,room).recordingId }}{% endif %}"
-         id="stopEgress"
-    >
-        <i class="fa-solid fa-record-vinyl blinking-red"></i>
+        <div class="wrapper {% if not getRecordingForRoomAndUser(app.user,room) %}d-none{% endif %}">
+            <div class=" conference-icon"
+                 data-url="{{ path('app_stop_egress',{'recordingId':'egressId'}) }}"
+                 data-egeressId="{% if getRecordingForRoomAndUser(app.user,room) %}{{ getRecordingForRoomAndUser(app.user,room).recordingId }}{% endif %}"
+                 id="stopEgress"
+            >
+                <i class="fa-solid fa-record-vinyl blinking-red"></i>
+            </div>
+            <div class="wrapper-helper">
+                {{ 'options.stopRecording'|trans }}
+            </div>
+        </div>
     </div>
-
-    <div class="wrapper-helper">
-        {{ 'options.stopRecording'|trans }}
-    </div>
-</div>
 {% endif %}
-
-


### PR DESCRIPTION
Behebt einen Bug, bei dem beim Starten/Stoppen einer Aufnahme die Egress-API doppelt aufgerufen wurde, weil die Click-Events mehrfach registriert wurden.

Was wurde geändert:
- Die Egress-Initialisierung (setupStartEgress / setupStopEgress) wurde aus initSocialIcons gelöscht und in eine neue function initRecording() in egress.js verschoben.
- initRecording() wird jetzt gezielt einmal beim Start der Konferenz in livekitUtils.js aufgerufen – statt über initSocialIcons (das doppelte Event-Listener verursachte).
- Die Recording-Buttons im Twig-Template sind nun in einem #wrapper-recording gekapselt, das erstmal (in Pre-Join-Page) ausgeblendet (d-none) ist und erst durch initRecording() eingeblendet wird.