### PR TITLE
Bugfix/mea 167 footer zentrieren for main

### DIFF
--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -1,4 +1,18 @@
 # Features, Improvements, and Bug Fixes in Jitsi Admin
+## 1.6
+* Removed matomo dependency
+* Centered footer
+
+
+## 1.5
+### 🚀 Features:
+### 🐛 Bug Fixes:
+* Fix duplicate recording API calls
+
+### ⭐ Improvements:
+* Add lobby moderator permission flag to the JWT
+* Redesigned homepage
+
 ## 1.4
 
 ### Features:
@@ -10,8 +24,6 @@
 * theme page is vissible
 * Fix button layout/rendering in all lobby instances
 
-
-# Features, Improvements, and Bug Fixes in Jitsi Admin
 ## 1.3
 
 ### Features:

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -1,15 +1,5 @@
 # Features, Improvements, and Bug Fixes in Jitsi Admin
 
-## 1.5
-### 🚀 Features:
-### 🐛 Bug Fixes:
-* Fix duplicate recording API calls
-* Centered footer
-
-### ⭐ Improvements:
-* Add lobby moderator permission flag to the JWT
-* Redesigned homepage
-
 ## 1.4
 
 ### Features:
@@ -20,6 +10,7 @@
 * Header shows Theme text
 * theme page is vissible
 * Fix button layout/rendering in all lobby instances
+* Centered footer (1.4.6)
 
 ## 1.3
 

--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -1,13 +1,10 @@
 # Features, Improvements, and Bug Fixes in Jitsi Admin
-## 1.6
-* Removed matomo dependency
-* Centered footer
-
 
 ## 1.5
 ### 🚀 Features:
 ### 🐛 Bug Fixes:
 * Fix duplicate recording API calls
+* Centered footer
 
 ### ⭐ Improvements:
 * Add lobby moderator permission flag to the JWT

--- a/assets/css/layout/_main.scss
+++ b/assets/css/layout/_main.scss
@@ -283,9 +283,7 @@ strong {
       list-style: none;
       margin: 6px 0 0;
       padding: 0;
-      display: flex;
-      justify-content: center;
-      flex: 1;
+      text-align: center;
       li {
         display: inline-block;
         .nav-link {

--- a/assets/css/layout/_main.scss
+++ b/assets/css/layout/_main.scss
@@ -283,6 +283,9 @@ strong {
       list-style: none;
       margin: 6px 0 0;
       padding: 0;
+      display: flex;
+      justify-content: center;
+      flex: 1;
       li {
         display: inline-block;
         .nav-link {


### PR DESCRIPTION

<img width="2560" height="100" alt="image" src="https://github.com/user-attachments/assets/a742db0f-0d22-4fb3-9259-22654df8963d" />


Neu zentriertes Footer-Menü
<img width="2560" height="100" alt="image" src="https://github.com/user-attachments/assets/12de744e-20a8-4a89-b013-6aa0bd254b1f" />
