### PR TITLE
Bugfix/anonymous users gaining moderator/lobbyModerator rights on unmoderated rooms

### DIFF
--- a/src/Service/RoomService.php
+++ b/src/Service/RoomService.php
@@ -128,14 +128,14 @@ class RoomService
         $roomUser = $this->findUserRoomAttributeForRoomAndUser($user, $room);
 
         $moderator = false;
-        if ($room->getModerator() === $user || $roomUser->getModerator()) {
+        if (($user !== null && $room->getModerator() === $user) || $roomUser->getModerator()) {
             $moderator = true;
         }
         if ($moderatorExplizit === true) {
             $moderator = true;
         }
         $lobbyModerator = false;
-        if ($room->getModerator() === $user || $roomUser->getLobbyModerator()) {
+        if (($user !== null && $room->getModerator() === $user) || $roomUser->getLobbyModerator()) {
             $lobbyModerator = true;
         }
         $avatar = null;

--- a/tests/JWTGenerateTest.php
+++ b/tests/JWTGenerateTest.php
@@ -169,11 +169,8 @@ final class JWTGenerateTest extends TestCase
             true,
         );
 
-        $expected = $this->expectedPayload();
-        $expected['lobbyModerator'] = true;
-
         self::assertSame(
-            JWT::encode($expected, self::APP_SECRET, 'HS256'),
+            JWT::encode($this->expectedPayload(), self::APP_SECRET, 'HS256'),
             $jwt,
         );
     }


### PR DESCRIPTION
Anonymous participants were incorrectly granted moderator/lobby-moderator rights whenever a room had no moderator set, due to a null === null identity comparison. Fixed by requiring an actual user before that comparison applies. Covered by JWTGenerateTest.

Related to: #765