### PR TITLE
Add pr template and automated changelog generation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,3 @@ label instead so it's left out of the changelog entirely.
 ```changelog
 
 ```
-
-## Testing
-
-<!-- How did you verify this change? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Changelog
+
+<!--
+One short, user-facing sentence describing this change for the release notes, inside the fenced
+block below. Write it for someone using Jitsi Admin, not for a reviewer (avoid ticket IDs,
+internal file/class names).
+If this PR has no user-facing effect (e.g. CI, tests, internal refactor), add the "no changelog"
+label instead so it's left out of the changelog entirely.
+-->
+```changelog
+
+```
+
+## Testing
+
+<!-- How did you verify this change? -->

--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -1,0 +1,50 @@
+{
+  "categories": [
+    {
+      "title": "### 🚀 Features",
+      "labels": ["feature"],
+      "exclude_labels": ["bugfix", "improvement"],
+      "rules": [
+        { "pattern": "^feature/", "on_property": "branch", "flags": "i" }
+      ]
+    },
+    {
+      "title": "### 🐛 Bug Fixes",
+      "labels": ["bugfix"],
+      "exclude_labels": ["feature", "improvement"],
+      "rules": [
+        { "pattern": "^(bugfix|hotfix)/", "on_property": "branch", "flags": "i" }
+      ]
+    },
+    {
+      "title": "### ⭐ Improvements",
+      "labels": ["improvement"],
+      "exclude_labels": ["feature", "bugfix"],
+      "rules": [
+        { "pattern": "^(refactor|l10n_release)/", "on_property": "branch", "flags": "i" }
+      ]
+    }
+  ],
+  "ignore_labels": ["no changelog"],
+  "sort": {
+    "order": "ASC",
+    "on_property": "mergedAt"
+  },
+  "template": "#{{CHANGELOG}}\n\n#{{UNCATEGORIZED}}\n\n**Full Changelog**: #{{RELEASE_DIFF}}\n\n👥 Contributors: #{{CONTRIBUTORS}}",
+  "pr_template": "- #{{CHANGELOG_ENTRY}} (##{{NUMBER}})",
+  "custom_placeholders": [
+    {
+      "name": "CHANGELOG_ENTRY",
+      "source": "BODY",
+      "transformer": {
+        "pattern": "[\\s\\S]*?```changelog\\s*\\r?\\n([\\s\\S]*?)\\r?\\n```[\\s\\S]*",
+        "target": "$1",
+        "flags": "i",
+        "on_empty": "_(no changelog entry provided — see PR title: #{{TITLE}})_"
+      }
+    }
+  ],
+  "empty_template": "- no changes",
+  "trim_values": true,
+  "max_pull_requests": 200
+}

--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -30,7 +30,7 @@
     "order": "ASC",
     "on_property": "mergedAt"
   },
-  "template": "#{{CHANGELOG}}\n\n#{{UNCATEGORIZED}}\n\n**Full Changelog**: #{{RELEASE_DIFF}}\n\n👥 Contributors: #{{CONTRIBUTORS}}",
+  "template": "#{{CHANGELOG}}\n\n#{{UNCATEGORIZED}}\n\n**Full Changelog**: #{{RELEASE_DIFF}}",
   "pr_template": "- #{{CHANGELOG_ENTRY}} (##{{NUMBER}})",
   "custom_placeholders": [
     {

--- a/.github/workflows/pipeline-changelog.yml
+++ b/.github/workflows/pipeline-changelog.yml
@@ -1,7 +1,8 @@
 name: Check Changelog
+
 on:
   pull_request:
-    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    types: [assigned, opened, edited, synchronize, reopened, labeled, unlabeled]
     branches:
       - master
       - feature/development
@@ -9,13 +10,30 @@ on:
       - hotfix/*
 
 jobs:
-  build:
-    name: Check Actions
+  check:
+    name: Check Changelog
     runs-on: ubuntu-latest
     steps:
-      - name: Update Repository
-        uses: actions/checkout@v1
-
-      - uses: tarides/changelog-check-action@v2
+      - name: Require a changelog entry or an opt-out label
+        uses: actions/github-script@v7
         with:
-          changelog: RELEASE_NOTE.md
+          script: |
+            const pr = context.payload.pull_request;
+
+            const labels = pr.labels.map(l => l.name);
+            if (labels.includes('no changelog')) {
+              core.info('Skipping: PR is labeled "no changelog".');
+              return;
+            }
+
+            const body = pr.body || '';
+            const match = body.match(/```changelog\s*\r?\n([\s\S]*?)\r?\n```/i);
+            const entry = (match ? match[1] : '').trim();
+
+            if (!entry) {
+              core.setFailed(
+                'No changelog entry found. Fill in the ```changelog``` block of the PR ' +
+                'description with a short, user-facing sentence, or add the "no changelog" ' +
+                'label if this PR has no user-facing effect.'
+              );
+            }

--- a/.github/workflows/pipeline-changelog.yml
+++ b/.github/workflows/pipeline-changelog.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - feature/development
+      - release/*
       - unstable/*
       - hotfix/*
 

--- a/.github/workflows/task-release.yml
+++ b/.github/workflows/task-release.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/download-artifact@v4
         with:
@@ -43,6 +45,16 @@ jobs:
           filename: 'websocket.zip'
           directory: artifact/nodejs
 
+      - name: Build changelog
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v6
+        with:
+          configuration: .github/changelog-configuration.json
+          ignorePreReleases: true
+          toTag: ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create new Release with semantic-version tag
         uses: ncipollo/release-action@v1
         id: create_release
@@ -53,4 +65,4 @@ jobs:
           tag: ${{ inputs.version }}
           artifacts: artifact/application.zip,artifact/nodejs/websocket.zip
           artifactContentType: application/zip
-          bodyFile: RELEASE_NOTE.md
+          body: ${{ steps.build_changelog.outputs.changelog }}


### PR DESCRIPTION
## Summary
  - Ersetzt die manuell gepflegte `RELEASE_NOTE.md` durch einen automatisch generierten Changelog,
    der aus den gemergten PRs zum Release-Zeitpunkt gebaut wird.
  - PRs deklarieren ihren Changelog-Eintrag jetzt direkt inline (in einem ```changelog```-Block
    in der PR-Beschreibung) statt eine gemeinsame Datei zu editieren. 
    Der merge-konfliktanfällige Workflow rund um RELEASE_NOTE.md entfällt.

  ## Was sich ändert
  - `.github/changelog-configuration.json` *(neu)* - kategorisiert PRs anhand des Branch-Prefixes
    in 🚀 Features / 🐛 Bug Fixes / ⭐ Improvements, mit optionalem Label-Override
    (`feature`/`bugfix`/`improvement`) und Opt-out-Label (`no changelog`, entspricht dem Label,
    das im Repo bereits existierte).
  - `.github/PULL_REQUEST_TEMPLATE.md` *(neu)* - fügt Summary- und Changelog Abschnitte
    hinzu; der Changelog-Abschnitt nutzt einen ```changelog```-Block, nach demselben Muster wie
    die `release-note`-Blöcke bei Kubernetes.
  - `.github/workflows/pipeline-changelog.yml` *(neu geschrieben)* - vorher
    `tarides/changelog-check-action`, das eine Änderung an `RELEASE_NOTE.md` erzwang; jetzt ein
    `actions/github-script`-Check, der entweder einen ausgefüllten Changelog-Block oder das Label
    `no changelog` auf dem PR voraussetzt.
  - `.github/workflows/task-release.yml` - neuer Schritt `Build changelog`
    (`mikepenz/release-changelog-builder-action`) vor der Release-Erstellung; der Release-Body ist
    jetzt direkt der generierte Changelog statt `bodyFile: RELEASE_NOTE.md`.
  - `RELEASE_NOTE.md` - vollständig abgelöst.
  
  Hinzufügen eines Changlog in der PR Description via
<pre><code>```changelog
Hier der Changelog
```</code></pre>
Nach dem merge in den Main Branch steht das neue PR Template zur Verfügung, sodass hier nur eingetragen werden muss.
