### PR TITLE
Feature/ma 227 date time auf date time immutable umstellen

### DIFF
--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -1,5 +1,10 @@
 # Features, Improvements, and Bug Fixes in Jitsi Admin
 
+## 1.7
+### 🚀 Features:
+* Convert all DateTime usages to DateTimeImmutable
+
+
 ## 1.6
 ### 🚀 Features:
 

--- a/src/Command/CheckThemeValidDateCommand.php
+++ b/src/Command/CheckThemeValidDateCommand.php
@@ -56,8 +56,8 @@ class CheckThemeValidDateCommand extends Command
             }
 
             if ($validUntil) {
-                $validDate = new \DateTime($validUntil);
-                $now = new \DateTime();
+                $validDate = new \DateTimeImmutable($validUntil);
+                $now = new \DateTimeImmutable();
                 $daysDifff = intval(($now->diff($validDate))->format('%R%a'));
                 if ($daysDifff < $maxTime && $daysDifff > 0) {
 

--- a/src/Command/CronSendReminderCommand.php
+++ b/src/Command/CronSendReminderCommand.php
@@ -50,8 +50,8 @@ class CronSendReminderCommand extends Command
         $io->writeln('Hinweis: ' . $res['hinweis']);
         $io->writeln('Konferenzen: ' . $res['Konferenzen']);
         $io->writeln('Emails: ' . $res['Emails']);
-        $io->writeln('Datum: ' . (new \DateTime())->format('d.m.Y'));
-        $io->writeln('Zeit: ' . (new \DateTime())->format('H:i'));
+        $io->writeln('Datum: ' . (new \DateTimeImmutable())->format('d.m.Y'));
+        $io->writeln('Zeit: ' . (new \DateTimeImmutable())->format('H:i'));
         if (!$res['error']) {
             $io->success('Erfolgreich versandt');
             return Command::SUCCESS;

--- a/src/Command/LobbyMessage/LobbyMessageCreateCommand.php
+++ b/src/Command/LobbyMessage/LobbyMessageCreateCommand.php
@@ -52,8 +52,7 @@ class LobbyMessageCreateCommand extends Command
 
 
         $message = new PredefinedLobbyMessages();
-        $message->setText($text)
-            ->setCreatedAt(new \DateTime());
+        $message->setText($text)->setCreatedAt(new \DateTimeImmutable());
         $prio = $input->getArgument('prio');
         if ($prio) {
             $io->note(sprintf('We create a new Predefined message with the prio: %d', $prio));

--- a/src/Command/MigrateTimeZoneCommand.php
+++ b/src/Command/MigrateTimeZoneCommand.php
@@ -33,14 +33,14 @@ class MigrateTimeZoneCommand extends Command
             $timezone = $data->getTimeZone() ? new \DateTimeZone($data->getTimeZone()) : null;
 
             if ($data->getStart()) {
-                $dateStart = new \DateTime($data->getStart()->format('Y-m-d H:i:s'), $timezone);
+                $dateStart = new \DateTimeImmutable($data->getStart()->format('Y-m-d H:i:s'), $timezone);
                 $data->setStartUtc($dateStart->setTimezone(new \DateTimeZone('utc')));
-                $data->setStartTimestamp((new \DateTime($data->getStart()->format('Y-m-d H:i:s'), $timezone))->getTimestamp());
+                $data->setStartTimestamp((new \DateTimeImmutable($data->getStart()->format('Y-m-d H:i:s'), $timezone))->getTimestamp());
             }
             if ($data->getEnddate()) {
-                $dateEnd = new \DateTime($data->getEnddate()->format('Y-m-d H:i:s'), $timezone);
+                $dateEnd = new \DateTimeImmutable($data->getEnddate()->format('Y-m-d H:i:s'), $timezone);
                 $data->setEndDateUtc($dateEnd->setTimezone(new \DateTimeZone('utc')));
-                $data->setEndTimestamp((new \DateTime($data->getEnddate()->format('Y-m-d H:i:s'), $timezone))->getTimestamp());
+                $data->setEndTimestamp((new \DateTimeImmutable($data->getEnddate()->format('Y-m-d H:i:s'), $timezone))->getTimestamp());
             }
             $this->em->persist($data);
         }

--- a/src/Command/SystemRepairCommand.php
+++ b/src/Command/SystemRepairCommand.php
@@ -43,7 +43,7 @@ class SystemRepairCommand extends Command
         $this->io = $io;
         $io->info('We try to repair the system.....');
         $this->logFileFile = fopen($this->logfile, "a") or die("Unable to open file!");
-        fwrite($this->logFileFile, sprintf(PHP_EOL . PHP_EOL . 'Repair on %s' . PHP_EOL, (new \DateTime())->format('d.m.Y H:i')));
+        fwrite($this->logFileFile, sprintf(PHP_EOL . PHP_EOL . 'Repair on %s' . PHP_EOL, (new \DateTimeImmutable())->format('d.m.Y H:i')));
         $count = 0;
         $user = $this->em->getRepository(User::class)->findAll();
         $io->info('--------We start with the users------');
@@ -69,7 +69,7 @@ class SystemRepairCommand extends Command
         $this->em->flush();
         $lobbyWaitingUser = $this->em->getRepository(LobbyWaitungUser::class)->findAll();
         foreach ($lobbyWaitingUser as $waitingUser) {
-            if ($waitingUser->getCreatedAt() < (new \DateTime())->modify('-10days')) {
+            if ($waitingUser->getCreatedAt() < (new \DateTimeImmutable())->modify('-10days')) {
                 $count++;
                 $this->em->remove($waitingUser);
             }

--- a/src/Controller/CalendlyWebhookApiController.php
+++ b/src/Controller/CalendlyWebhookApiController.php
@@ -168,10 +168,10 @@ class CalendlyWebhookApiController extends AbstractController
                         }
                         if ($server) {
 
-                            $startTime = new \DateTime($body['payload']['scheduled_event']['start_time'], new \DateTimeZone('UTC'));
-                            $startTime->setTimezone(new \DateTimeZone($body['payload']['timezone']));
-                            $endTime = new \DateTime($body['payload']['scheduled_event']['end_time'], new \DateTimeZone('UTC'));
-                            $endTime->setTimezone(new \DateTimeZone($body['payload']['timezone']));
+                            $startTime = new \DateTimeImmutable($body['payload']['scheduled_event']['start_time'], new \DateTimeZone('UTC'));
+                            $startTime = $startTime->setTimezone(new \DateTimeZone($body['payload']['timezone']));
+                            $endTime = new \DateTimeImmutable($body['payload']['scheduled_event']['end_time'], new \DateTimeZone('UTC'));
+                            $endTime = $endTime->setTimezone(new \DateTimeZone($body['payload']['timezone']));
                             $duration = $startTime->diff($endTime);
                             $eventNAme = $body['payload']['scheduled_event']['name'] . ' | ' . $body['payload']['name'] . ' from calendly';
                             $newRoom = $this->roomService->createRoom($user, $server, $startTime, $duration->i, $eventNAme);

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -129,8 +129,8 @@ class DashboardController extends JitsiAdminController
         }
 
         $servers = $serverUserManagment->getServersFromUser($this->getUser());
-        $today = (new \DateTime('now'))->setTimezone(new \DateTimeZone($this->getUser()->getTimeZone()));
-        $tomorrow = (clone $today)->modify('+1day');
+        $today = (new \DateTimeImmutable('now'))->setTimezone(new \DateTimeZone($this->getUser()->getTimeZone()));
+        $tomorrow = $today->modify('+1day');
         $favorites = $this->doctrine->getRepository(Rooms::class)->findFavoriteRooms($this->getUser());
         foreach ($favorites as $room) {
             $roomIds[] = $room->getId();
@@ -160,7 +160,7 @@ class DashboardController extends JitsiAdminController
                 $this->addFlash($request->get('color'), $request->get('snack'));
             }
         }
-        $date = new \DateTime();
+        $date = new \DateTimeImmutable();
         $timestamp = $date->getTimestamp();
         $form = $this->createForm(
             SecondEmailType::class,

--- a/src/Controller/OwnRoomController.php
+++ b/src/Controller/OwnRoomController.php
@@ -38,8 +38,8 @@ class OwnRoomController extends JitsiAdminController
         }
 
         if (!StartMeetingService::checkTime($rooms)) {
-            $startPrint = $rooms->getTimeZone() ? clone ($rooms->getStartUtc())->setTimeZone(new \DateTimeZone($rooms->getTimeZone())) : $rooms->getStart();
-            $startPrint->modify('-30min');
+            $startPrint = $rooms->getTimeZone() ? $rooms->getStartUtc()->setTimeZone(new \DateTimeZone($rooms->getTimeZone())) : $rooms->getStart();
+            $startPrint = $startPrint->modify('-30min');
             $endPrint = $rooms->getTimeZone() ? $rooms->getEndDateUtc()->setTimeZone(new \DateTimeZone($rooms->getTimeZone())) : $rooms->getEnddate();
             $snack = $translator->trans(
                 'Der Beitritt ist nur von {from} bis {to} möglich',
@@ -116,7 +116,7 @@ class OwnRoomController extends JitsiAdminController
                             $wui = $request->cookies->get('waitinguser');
                         }
                         $res = $startMeetingService->createLobbyParticipantResponse($wui);
-                        $res->headers->setCookie(new Cookie('waitinguser', $startMeetingService->getLobbyUser()->getUid(), (new \DateTime())->modify('+6 hours')));
+                        $res->headers->setCookie(new Cookie('waitinguser', $startMeetingService->getLobbyUser()->getUid(), (new \DateTimeImmutable())->modify('+6 hours')));
                     }
                 } else {
                     if ($this->getUser() === $rooms->getModerator()) {
@@ -136,7 +136,7 @@ class OwnRoomController extends JitsiAdminController
                             $wui = $request->cookies->get('waitinguser');
                         }
                         $res = $startMeetingService->createLobbyParticipantResponse($wui);
-                        $res->headers->setCookie(new Cookie('waitinguser', $startMeetingService->getLobbyUser()->getUid(), (new \DateTime())->modify('+6 hours')));
+                        $res->headers->setCookie(new Cookie('waitinguser', $startMeetingService->getLobbyUser()->getUid(), (new \DateTimeImmutable())->modify('+6 hours')));
                     }
                 } else {//Der Raum hat keine Lobby Aktiviert -->
                     // Der Fall hier: 1. Keine Zeit angegeben,
@@ -145,7 +145,7 @@ class OwnRoomController extends JitsiAdminController
                     $res = $startMeetingService->roomDefault();
                 }
             }
-            $res->headers->setCookie(new Cookie('name', $name, (new \DateTime())->modify('+365 days')));
+            $res->headers->setCookie(new Cookie('name', $name, (new \DateTimeImmutable())->modify('+365 days')));
             return $res;
         }
 
@@ -165,7 +165,7 @@ class OwnRoomController extends JitsiAdminController
         $room = $this->doctrine->getRepository(Rooms::class)->findOneBy(['uid' => $request->get('uid')]);
         $name = $request->get('name');
         $type = $request->get('type');
-        $now = new \DateTime('now', new \DateTimeZone('utc'));
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('utc'));
 
         if (($room->getStartUtc() < $now && $room->getEndDateUtc() > $now)) {
             $startMeetingService->setAttribute($room, null, $type, $name);
@@ -208,7 +208,7 @@ class OwnRoomController extends JitsiAdminController
               $name, $type,
     ): Response
     {
-        $now = new \DateTime('now', new \DateTimeZone('utc'));
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('utc'));
 
         if (($rooms->getStartUtc() < $now && $rooms->getEndDateUtc() > $now)) {
             return new JsonResponse(['error' => false, 'url' => $this->generateUrl('room_waiting', ['name' => $name, 'type' => $type, 'uid' => $rooms->getUid()])]);

--- a/src/Controller/ProfileImageChangeController.php
+++ b/src/Controller/ProfileImageChangeController.php
@@ -73,8 +73,8 @@ class ProfileImageChangeController extends JitsiAdminController
                     }
                 }
 
-                $user->getProfilePicture()->setUpdatedAt(new \DateTime());
-                $user->setUpdatedAt(new \DateTime());
+                $user->getProfilePicture()->setUpdatedAt(new \DateTimeImmutable());
+                $user->setUpdatedAt(new \DateTimeImmutable());
                 $em = $this->doctrine->getManager();
                 $em->persist($user);
                 $em->flush();

--- a/src/Controller/ReminderLizenseController.php
+++ b/src/Controller/ReminderLizenseController.php
@@ -24,8 +24,8 @@ class ReminderLizenseController extends JitsiAdminController
             return new JsonResponse($message);
         }
         $counter = 0;
-        $back = (new \DateTime())->modify('+5 days');
-        $now = new \DateTime();
+        $back = (new \DateTimeImmutable())->modify('+5 days');
+        $now = new \DateTimeImmutable();
         $qb = $this->doctrine->getRepository(License::class)->createQueryBuilder('license');
         $qb->andWhere($qb->expr()->gte('license.validUntil', ':now'))
             ->setParameter('now', $now)

--- a/src/Controller/RepeaterController.php
+++ b/src/Controller/RepeaterController.php
@@ -203,7 +203,7 @@ class RepeaterController extends JitsiAdminController
             'isEdit' => true
         ];
         if ($request->get('type') === 'all') {
-            if (new \DateTime() > $room->getStart()) {
+            if (new \DateTimeImmutable() > $room->getStart()) {
                 $option['minDate'] = $room->getStart()->format('m/d/Y');
             }
         }
@@ -220,7 +220,7 @@ class RepeaterController extends JitsiAdminController
                 $em = $this->doctrine->getManager();
                 $room = $form->getData();
                 if ($room->getRepeaterRemoved()) {//this is a single room. So we take the room out of the series
-                    $room->setEnddate((clone $room->getStart())->modify('+' . $room->getDuration() . 'min'));
+                    $room->setEnddate($room->getStart()->modify('+' . $room->getDuration() . 'min'));
                     $em->persist($room);
                     $em->flush();
                     $repeater = $room->getRepeater();

--- a/src/Controller/ReportController.php
+++ b/src/Controller/ReportController.php
@@ -31,7 +31,7 @@ class ReportController extends AbstractController
         if (!UtilsHelper::isAllowedToOrganizeRoom($this->getUser(), $room)) {
             throw  new NotFoundHttpException('Room not Found');
         }
-        $timeZone = $this->getUser()->getTimeZone() ? $this->getUser()->getTimeZone() : (new \DateTime())->getTimezone()->getName();
+        $timeZone = $this->getUser()->getTimeZone() ? $this->getUser()->getTimeZone() : (new \DateTimeImmutable())->getTimezone()->getName();
         return $this->render(
             'report/index.html.twig',
             [

--- a/src/Controller/ScheduleController.php
+++ b/src/Controller/ScheduleController.php
@@ -22,7 +22,7 @@ use App\Service\ServerUserManagment;
 use App\Service\UserService;
 use App\Util\CsvHandler;
 use App\UtilsHelper;
-use DateTime;
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use Exception;
@@ -253,7 +253,7 @@ class ScheduleController extends JitsiAdminController
             }
             $em = $this->doctrine->getManager();
             $scheduleTime = new SchedulingTime();
-            $scheduleTime->setTime(new DateTime($request->get('date')));
+            $scheduleTime->setTime(new DateTimeImmutable($request->get('date')));
             $scheduleTime->setScheduling($schedule);
             $schedule->setCompletedEmailSent(false);
             $em->persist($schedule);
@@ -414,7 +414,7 @@ class ScheduleController extends JitsiAdminController
             'Content-Disposition',
             HeaderUtils::makeDisposition(
                 HeaderUtils::DISPOSITION_ATTACHMENT,
-                preg_replace('/[[:^print:]]/', '', $room->getName()) . '-' . (new DateTime())->format('d-m-Y_H-i') . '.csv',
+                preg_replace('/[[:^print:]]/', '', $room->getName()) . '-' . (new DateTimeImmutable())->format('d-m-Y_H-i') . '.csv',
             )
         );
         return $response;

--- a/src/Controller/SchedulerPublicCreatorController.php
+++ b/src/Controller/SchedulerPublicCreatorController.php
@@ -69,7 +69,7 @@ class SchedulerPublicCreatorController extends AbstractController
             }
 
             $scheduleTime = new SchedulingTime();
-            $scheduleTime->setTime(new \DateTime($request->get('date')));
+            $scheduleTime->setTime(new \DateTimeImmutable($request->get('date')));
             $scheduleTime->setScheduling($schedule);
             $scheduleTime->setCreatedFrom($user);
             $schedule->addSchedulingTime($scheduleTime);

--- a/src/Controller/SecondEmailChangeController.php
+++ b/src/Controller/SecondEmailChangeController.php
@@ -59,8 +59,8 @@ class SecondEmailChangeController extends JitsiAdminController
                     }
                 }
 
-                $user->getProfilePicture()->setUpdatedAt(new \DateTime());
-                $user->setUpdatedAt(new \DateTime());
+                $user->getProfilePicture()->setUpdatedAt(new \DateTimeImmutable());
+                $user->setUpdatedAt(new \DateTimeImmutable());
                 $em = $this->doctrine->getManager();
                 $em->persist($user);
                 $em->flush();

--- a/src/Controller/ServersController.php
+++ b/src/Controller/ServersController.php
@@ -116,8 +116,8 @@ class ServersController extends JitsiAdminController
                 $em->persist($server);
                 $em->flush();
                 if ($server->getServerBackgroundImage()) {
-                    $server->getServerBackgroundImage()->setUpdatedAt(new \DateTime());
-                    $server->setUpdatedAt(new \DateTime());
+                    $server->getServerBackgroundImage()->setUpdatedAt(new \DateTimeImmutable());
+                    $server->setUpdatedAt(new \DateTimeImmutable());
                     $em->persist($server);
                     $em->flush();
                 }

--- a/src/Controller/api/APIRoomController.php
+++ b/src/Controller/api/APIRoomController.php
@@ -52,7 +52,7 @@ class APIRoomController extends JitsiAdminController
             return new JsonResponse(['error' => true, 'text' => 'No Server found']);
         }
         //we create the start Datetime
-        $start = new \DateTime($request->get('start'));
+        $start = new \DateTimeImmutable($request->get('start'));
         $duration = $request->get('duration');
         $name = $request->get('name');
         //we are looking for the server with the Email and the ServerUrl
@@ -97,7 +97,7 @@ class APIRoomController extends JitsiAdminController
         };
 
         //we create the start Datetime
-        $start = new \DateTime($request->get('start'));
+        $start = new \DateTimeImmutable($request->get('start'));
         $duration = $request->get('duration');
         $name = $request->get('name');
         //we are looking for the server with the Email and the ServerUrl

--- a/src/Controller/api/ServerAPIController.php
+++ b/src/Controller/api/ServerAPIController.php
@@ -40,7 +40,7 @@ class ServerAPIController extends AbstractController
             ->setServerName($request->get('name'))
             ->setAppId($request->get('app_id'))
             ->setAppSecret($request->get('app_secret'))
-            ->setUpdatedAt(new \DateTime())
+            ->setUpdatedAt(new \DateTimeImmutable())
             ->setAllowedToCloneForAutoscale(null)
             ->setSlug(urlencode($newServer->getUrl()));
         $newServer->getUser()->clear();

--- a/src/DataFixtures/RoomFixture.php
+++ b/src/DataFixtures/RoomFixture.php
@@ -28,7 +28,7 @@ class RoomFixture extends Fixture
         // create a user
         $user = new \App\Entity\User();
         $user->setEmail('test@local.de');
-        $user->setCreatedAt(new \DateTime());
+        $user->setCreatedAt(new \DateTimeImmutable());
         $user->setKeycloakId('123456');
         $user->setFirstName('Test');
         $user->setLastName('User');
@@ -38,14 +38,14 @@ class RoomFixture extends Fixture
         $user->setUuid('lksdhflkjdsljflkjds');
         $user->setUid('kljlsdkjflkjdslfjsjkldlkjsdflkj');
         $user->setUsername('test@local.de');
-        $user->setCreatedAt(new \DateTime());
+        $user->setCreatedAt(new \DateTimeImmutable());
         $user->setIndexer('test@local.de test@local.de test user test1 1234 0123456789');
         $manager->persist($user);
 
 
         $user2 = new \App\Entity\User();
         $user2->setEmail('test@local2.de');
-        $user2->setCreatedAt(new \DateTime());
+        $user2->setCreatedAt(new \DateTimeImmutable());
         $user2->setKeycloakId(123456);
         $user2->setFirstName('Test2');
         $user2->setLastName('User2');
@@ -55,14 +55,14 @@ class RoomFixture extends Fixture
         $user2->setUuid('lksdhflkjdsljflhjkkjds');
         $user2->setUid('kljlsdkjflkjddfgslfjsdlkjsdflkj');
         $user2->setUsername('test2@local.de');
-        $user2->setCreatedAt(new \DateTime());
+        $user2->setCreatedAt(new \DateTimeImmutable());
         $user2->setIndexer('test@local2.de test@local2.de test2 user2 test2 1234 9876543210');
         $manager->persist($user2);
 
 
         $userLDAP = new \App\Entity\User();
         $userLDAP->setEmail('ldapUser@local.de');
-        $userLDAP->setCreatedAt(new \DateTime());
+        $userLDAP->setCreatedAt(new \DateTimeImmutable());
         $userLDAP->setKeycloakId(123456);
         $userLDAP->setFirstName('LdapUSer');
         $userLDAP->setLastName('Ldap');
@@ -72,7 +72,7 @@ class RoomFixture extends Fixture
         $userLDAP->setUuid('dfsdffscxv');
         $userLDAP->setUid('kljlsdkjflkjxcvvxcxcvddfgslfjsdlkjsdflkj');
         $userLDAP->setUsername('ldapUser@local.de');
-        $userLDAP->setCreatedAt(new \DateTime());
+        $userLDAP->setCreatedAt(new \DateTimeImmutable());
         $userLDAP->setIndexer('ldapuser@local.de ldapuser@local.de ldapuser ldap aa 45689 987654321012');
         $manager->persist($userLDAP);
         $ldapUserProperty = new LdapUserProperties();
@@ -87,9 +87,9 @@ class RoomFixture extends Fixture
         $user3 = new \App\Entity\User();
         $user3->setEmail('test@local3.de');
         $user3->setUsername('test@local3.de');
-        $user3->setCreatedAt(new \DateTime());
+        $user3->setCreatedAt(new \DateTimeImmutable());
         $user3->setRegisterId(123456);
-        $user3->setCreatedAt(new \DateTime());
+        $user3->setCreatedAt(new \DateTimeImmutable());
         $user3->setUid('kjsdfhkjds');
         $user3->setIndexer('test@local3.de test@local3.de');
         $manager->persist($user3);
@@ -97,9 +97,9 @@ class RoomFixture extends Fixture
         $user4 = new \App\Entity\User();
         $user4->setEmail('test@local4.de');
         $user4->setUsername('test@local4.de');
-        $user4->setCreatedAt(new \DateTime());
+        $user4->setCreatedAt(new \DateTimeImmutable());
         $user4->setRegisterId(123456);
-        $user4->setCreatedAt(new \DateTime());
+        $user4->setCreatedAt(new \DateTimeImmutable());
         $user4->setUid('bjhxbcvuzcbxv7');
         $user4->setIndexer('test@local4.de test@local4.de');
         $manager->persist($user4);
@@ -107,7 +107,7 @@ class RoomFixture extends Fixture
         // create a user
         $user5 = new \App\Entity\User();
         $user5->setEmail('test@australia.de');
-        $user5->setCreatedAt(new \DateTime());
+        $user5->setCreatedAt(new \DateTimeImmutable());
         $user5->setKeycloakId('123456');
         $user5->setFirstName('Test');
         $user5->setLastName('User');
@@ -117,13 +117,13 @@ class RoomFixture extends Fixture
         $user5->setUuid('lksdhflkjdsljflkjds');
         $user5->setUid('kljlsdkjflkjdslfjsjkldlkjsdflkj');
         $user5->setUsername('test@australia.de');
-        $user5->setCreatedAt(new \DateTime());
+        $user5->setCreatedAt(new \DateTimeImmutable());
         $user5->setIndexer('test@australia.de test@australia.de test user test1 1234 0123456789');
         $manager->persist($user5);
 
         $user6 = new \App\Entity\User();
         $user6->setEmail('test@noTimeZone.de');
-        $user6->setCreatedAt(new \DateTime());
+        $user6->setCreatedAt(new \DateTimeImmutable());
         $user6->setKeycloakId('123456');
         $user6->setFirstName('Test');
         $user6->setLastName('User');
@@ -132,7 +132,7 @@ class RoomFixture extends Fixture
         $user6->setUuid('lksdhflkjdsljflkjds');
         $user6->setUid('kljlsdkjflkjdslfjsjkldlkjsdflkj');
         $user6->setUsername('test@noTimeZone.de');
-        $user6->setCreatedAt(new \DateTime());
+        $user6->setCreatedAt(new \DateTimeImmutable());
         $user6->setIndexer('test@noTimeZone.de test@noTimeZone.de test user test1 1234 0123456789');
         $manager->persist($user6);
 
@@ -142,12 +142,12 @@ class RoomFixture extends Fixture
         $deputy1 = new Deputy();
         $deputy1->setManager($user5)
             ->setDeputy($user6)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setIsFromLdap(true);
         $deputy2 = new Deputy();
         $deputy2->setManager($user5)
             ->setDeputy($user6)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setIsFromLdap(true);
 
 
@@ -200,7 +200,7 @@ class RoomFixture extends Fixture
         $license = new License();
         $license->setUrl('meet.jit.si2');
         $license->setLicense('{"signature":"4b1e1205ad1a492f33646c2f499c11b0252335b16da64d60804f6e0a5ca55b4c811bbad8faf0c3aef41a51ee94b5f93d4d2f5852e35a557280f06794bccbd5ee4cdd8e894f5d474f36b6127f77198a0a28cf369c447963f45b41ada180de36e309ea18b060dadfae53599118443c849cd86b78907d05ef5f376075c6bb7063682fbd05df57d3ec74b72b14f89bf2dc3defa8a2181bb12f0b5feef1e8cc731606b0e6c28a9e0d39c46d04cad228ab825457d79f8ec4047f5b8476fba742e18778b1934076767cc0e6fb874e865d1ac6ae5034282a9952c6091cf9f0bf16739c72c52e7e2d00ecad797cc3cc30f841dc3d0c51134a2a5200a40cec93c76e32038beaf4210973f3c946da8aeb06cb9c09d6bbb3e9137a5d88f3bf38f9ecfdab02117edc054161d2345ccc9d15bd9c59e696998e9d102d77ca2548f872a44f3150f81b24a28e741ee85ae99b24fd1938d5bcf906016ccf09a4f20da468113181b3b4653b2eff5ffc628692dd720c62fd063f5baa13c1a9ab60e88cc462efa15612bbbed1780a9c46ce851f422c7e5dd861f1aa7304d3cb87331d12e67496b39703d3e62f8305381343ee54f6dde8718a83581a12edceedbc0543f1ae226c1ae4acdaaa2ed09191593164dd2635319c09da53803d26a5cf14a84fb35a73d8688fdad251e33ed4719ee9d4281247d0cb1adfa62b220257e396a061d5598a4a401551dc","entry":{"valid_until":"2024-07-04","server_url":"meet.jit.si2","license_key":"f5c627f7ac98bef45fcfdd5fcade0246"}}');
-        $license->setValidUntil(new \DateTime('2024-07-04'));
+        $license->setValidUntil(new \DateTimeImmutable('2024-07-04'));
         $license->setLicenseKey('f5c627f7ac98bef45fcfdd5fcade0246');
         $manager->persist($license);
         $manager->flush();
@@ -231,9 +231,8 @@ class RoomFixture extends Fixture
             $room->setDuration(60);
             $room->setDissallowPrivateMessage(true);
             $room->setDissallowScreenshareGlobal(true);
-            $start = (new \DateTime())->setTimezone(new \DateTimeZone('Europe/Berlin'))->modify('+' . ($i * 2 + 1) . 'minutes');
-            $end = clone $start;
-            $end->modify('+60min');
+            $start = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone('Europe/Berlin'))->modify('+' . ($i * 2 + 1) . 'minutes');
+            $end = $start->modify('+60min');
             $room->setStart($start);
             $room->setEnddate($end);
             $room->addUser($user);
@@ -248,12 +247,12 @@ class RoomFixture extends Fixture
             $room->setServer($server);
             $callerRoom = new CallerRoom();
             $callerRoom->setCallerId('1234' . $i);
-            $callerRoom->setCreatedAt(new \DateTime());
+            $callerRoom->setCreatedAt(new \DateTimeImmutable());
             $room->setCallerRoom($callerRoom);
             $room->setHostUrl('http://localhost:8000');
             $manager->persist($room);
         }
-        $start = new \DateTime('2021-01-01T15:00');
+        $start = new \DateTimeImmutable('2021-01-01T15:00');
         for ($i = 0; $i < 20; $i++) {
             $room = new Rooms();
             $room->setTimeZone('Europe/Berlin');
@@ -281,8 +280,8 @@ class RoomFixture extends Fixture
             $selectDate->setRoom($room);
             for ($c = 0; $c < 5; $c++) {
                 $time = new SchedulingTime();
-                $time->setTime(clone $start);
-                $start->modify('+1day');
+                $time->setTime($start);
+                $start = $start->modify('+1day');
                 $selectDate->addSchedulingTime($time);
                 $manager->persist($time);
             }
@@ -299,9 +298,8 @@ class RoomFixture extends Fixture
             $room->setDuration(60);
             $room->setDissallowPrivateMessage(true);
             $room->setDissallowScreenshareGlobal(true);
-            $start = (new \DateTime())->setTimezone(new \DateTimeZone('America/Adak'))->modify('+' . ($i * 2) . 'minutes');
-            $end = clone $start;
-            $end->modify('+60min');
+            $start = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone('America/Adak'))->modify('+' . ($i * 2) . 'minutes');
+            $end = $start->modify('+60min');
             $room->setStart($start);
             $room->setEnddate($end);
             $room->addUser($user);
@@ -323,16 +321,15 @@ class RoomFixture extends Fixture
         $room->setCreator($user);
         $callerRoom = new CallerRoom();
         $callerRoom->setCallerId('1234noRight');
-        $callerRoom->setCreatedAt(new \DateTime());
+        $callerRoom->setCreatedAt(new \DateTimeImmutable());
         $room->setCallerRoom($callerRoom);
         $room->setCallerRoom($callerRoom);
         $room->setAgenda('Testagenda:');
         $room->setDuration(60);
         $room->setDissallowPrivateMessage(true);
         $room->setDissallowScreenshareGlobal(true);
-        $start = (new \DateTime())->setTimezone(new \DateTimeZone('Europe/Berlin'));
-        $end = clone $start;
-        $end->modify('+60min');
+        $start = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone('Europe/Berlin'));
+        $end = $start->modify('+60min');
         $room->setStart($start);
         $room->setEnddate($end);
         $room->setUid(md5(uniqid()));
@@ -351,9 +348,8 @@ class RoomFixture extends Fixture
         $room->setDuration(60);
         $room->setDissallowPrivateMessage(true);
         $room->setDissallowScreenshareGlobal(true);
-        $start = (new \DateTime('tomorrow'))->setTimezone(new \DateTimeZone('Europe/Berlin'))->setTime(10, 0);
-        $end = clone $start;
-        $end->modify('+60min');
+        $start = (new \DateTimeImmutable('tomorrow'))->setTimezone(new \DateTimeZone('Europe/Berlin'))->setTime(10, 0);
+        $end = $start->modify('+60min');
         $room->setStart($start);
         $room->setEnddate($end);
         $room->setModerator($user);
@@ -376,9 +372,8 @@ class RoomFixture extends Fixture
         $room->setDuration(60);
         $room->setDissallowPrivateMessage(true);
         $room->setDissallowScreenshareGlobal(true);
-        $start = (new \DateTime('yesterday'))->setTimezone(new \DateTimeZone('Europe/Berlin'))->setTime(10, 0);
-        $end = clone $start;
-        $end->modify('+60min');
+        $start = (new \DateTimeImmutable('yesterday'))->setTimezone(new \DateTimeZone('Europe/Berlin'))->setTime(10, 0);
+        $end = $start->modify('+60min');
         $room->setStart($start);
         $room->setEnddate($end);
         $room->setModerator($user);
@@ -395,7 +390,7 @@ class RoomFixture extends Fixture
         $room->setServer($server);
         $callerRoom = new CallerRoom();
         $callerRoom->setCallerId('123456');
-        $callerRoom->setCreatedAt(new \DateTime());
+        $callerRoom->setCreatedAt(new \DateTimeImmutable());
         $room->setCallerRoom($callerRoom);
         $manager->persist($room);
         $manager->flush();
@@ -406,9 +401,8 @@ class RoomFixture extends Fixture
         $room->setDuration(60);
         $room->setDissallowPrivateMessage(true);
         $room->setDissallowScreenshareGlobal(true);
-        $start = (new \DateTime())->setTimezone(new \DateTimeZone('Europe/Berlin'))->modify('-10min');
-        $end = clone $start;
-        $end->modify('+60min');
+        $start = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone('Europe/Berlin'))->modify('-10min');
+        $end = $start->modify('+60min');
         $room->setStart($start);
         $room->setEnddate($end);
         $room->setModerator($user);
@@ -430,66 +424,66 @@ class RoomFixture extends Fixture
 
         $roomStatus = new RoomStatus();
         $roomStatus->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
+            ->setRoomCreatedAt(new \DateTimeImmutable())
             ->setRoom($room)
             ->setJitsiRoomId('test@test.de')
-            ->setUpdatedAt(new \DateTime())
-            ->setCreatedAt(new \DateTime());
+            ->setUpdatedAt(new \DateTimeImmutable())
+            ->setCreatedAt(new \DateTimeImmutable());
         $manager->persist($roomStatus);
         $manager->flush();
 
         $roomStatusPart = new RoomStatusParticipant();
-        $roomStatusPart->setEnteredRoomAt(new \DateTime())
+        $roomStatusPart->setEnteredRoomAt(new \DateTimeImmutable())
             ->setInRoom(true)
             ->setParticipantId('inderKonferenz@test.de')
             ->setParticipantName('in der Konferenz')
             ->setRoomStatus($roomStatus)
-            ->setEnteredRoomAt(new \DateTime());
+            ->setEnteredRoomAt(new \DateTimeImmutable());
         $manager->persist($roomStatusPart);
         $manager->flush();
         $roomStatusPart = new RoomStatusParticipant();
-        $roomStatusPart->setEnteredRoomAt(new \DateTime())
+        $roomStatusPart->setEnteredRoomAt(new \DateTimeImmutable())
             ->setInRoom(false)
             ->setParticipantId('inderKonferenz3@test.de')
             ->setParticipantName('aus der Konferenz 1 Stunde')
             ->setRoomStatus($roomStatus)
-            ->setEnteredRoomAt(new \DateTime())
-            ->setLeftRoomAt((new \DateTime())->modify('+1hour'));
+            ->setEnteredRoomAt(new \DateTimeImmutable())
+            ->setLeftRoomAt((new \DateTimeImmutable())->modify('+1hour'));
         $manager->persist($roomStatusPart);
         $manager->flush();
 
         $roomStatusPart = new RoomStatusParticipant();
-        $roomStatusPart->setEnteredRoomAt(new \DateTime())
+        $roomStatusPart->setEnteredRoomAt(new \DateTimeImmutable())
             ->setInRoom(false)
             ->setParticipantId('inderKonferenz3@test.de')
             ->setParticipantName('aus der Konferenz 1 Tag')
             ->setRoomStatus($roomStatus)
-            ->setEnteredRoomAt(new \DateTime())
-            ->setLeftRoomAt((new \DateTime())->modify('+1day'));
+            ->setEnteredRoomAt(new \DateTimeImmutable())
+            ->setLeftRoomAt((new \DateTimeImmutable())->modify('+1day'));
         $manager->persist($roomStatusPart);
         $manager->flush();
 
 
         $roomStatus = new RoomStatus();
         $roomStatus->setCreated(true)
-            ->setRoomCreatedAt((new \DateTime())->modify('-2hours'))
+            ->setRoomCreatedAt((new \DateTimeImmutable())->modify('-2hours'))
             ->setRoom($room)
             ->setJitsiRoomId('test@test.de')
-            ->setUpdatedAt(new \DateTime())
-            ->setCreatedAt(new \DateTime())
+            ->setUpdatedAt(new \DateTimeImmutable())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setDestroyed(true)
-            ->setDestroyedAt((new \DateTime())->modify('-1hour'));
+            ->setDestroyedAt((new \DateTimeImmutable())->modify('-1hour'));
         $manager->persist($roomStatus);
         $manager->flush();
 
         $roomStatusPart = new RoomStatusParticipant();
-        $roomStatusPart->setEnteredRoomAt((new \DateTime())->modify('-2hours'))
+        $roomStatusPart->setEnteredRoomAt((new \DateTimeImmutable())->modify('-2hours'))
             ->setInRoom(false)
-            ->setLeftRoomAt((new \DateTime())->modify('-1hour'))
+            ->setLeftRoomAt((new \DateTimeImmutable())->modify('-1hour'))
             ->setParticipantId('inderKonferenz@test.de')
             ->setParticipantName('beim letzen mal')
             ->setRoomStatus($roomStatus)
-            ->setEnteredRoomAt(new \DateTime())
+            ->setEnteredRoomAt(new \DateTimeImmutable())
             ->setDominantSpeakerTime(11100000);
         $manager->persist($roomStatusPart);
         $manager->flush();
@@ -573,9 +567,8 @@ class RoomFixture extends Fixture
         $room->setDuration(60);
         $room->setDissallowPrivateMessage(true);
         $room->setDissallowScreenshareGlobal(true);
-        $start = (new \DateTime('tomorrow'))->setTimezone(new \DateTimeZone('Europe/Berlin'));
-        $end = clone $start;
-        $end->modify('+60min');
+        $start = (new \DateTimeImmutable('tomorrow'))->setTimezone(new \DateTimeZone('Europe/Berlin'));
+        $end = $start->modify('+60min');
         $room->setStart($start);
         $room->setEnddate($end);
         $room->setModerator($user);
@@ -598,9 +591,8 @@ class RoomFixture extends Fixture
         $room1->setDuration(60);
         $room1->setDissallowPrivateMessage(true);
         $room1->setDissallowScreenshareGlobal(true);
-        $start = (new \DateTime('tomorrow'))->setTimezone(new \DateTimeZone('Europe/Berlin'));
-        $end = clone $start;
-        $end->modify('+60min');
+        $start = (new \DateTimeImmutable('tomorrow'))->setTimezone(new \DateTimeZone('Europe/Berlin'));
+        $end = $start->modify('+60min');
         $room1->setStart($start);
         $room1->setEnddate($end);
         $room1->setModerator($user);
@@ -617,14 +609,15 @@ class RoomFixture extends Fixture
         $room1->setServer($server);
         $manager->persist($room1);
         $manager->flush();
-        $lobbyTime = new \DateTime();
+        $lobbyTime = new \DateTimeImmutable();
         for ($i = 0; $i < 10; $i++) {
             $lobbyUser = new LobbyWaitungUser();
             $lobbyUser->setWebsocketReady(true);
             $lobbyUser->setUser($user);
             $lobbyUser->setRoom($room1);
             $lobbyUser->setUid(md5($i));
-            $lobbyUser->setCreatedAt(clone($lobbyTime->modify('-1 hour')));
+            $lobbyTime = $lobbyTime->modify('-1 hour');
+            $lobbyUser->setCreatedAt($lobbyTime);
             $lobbyUser->setShowName('LobbyUser ' . $i);
             $lobbyUser->setType('a');
             $manager->persist($lobbyUser);
@@ -637,9 +630,8 @@ class RoomFixture extends Fixture
         $room->setDuration(60);
         $room->setDissallowPrivateMessage(true);
         $room->setDissallowScreenshareGlobal(true);
-        $start = (new \DateTime())->setTimezone(new \DateTimeZone('Europe/Berlin'))->modify('-10min');
-        $end = clone $start;
-        $end->modify('+60min');
+        $start = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone('Europe/Berlin'))->modify('-10min');
+        $end = $start->modify('+60min');
         $room->setStart($start);
         $room->setEnddate($end);
         $room->setModerator($user);
@@ -660,7 +652,7 @@ class RoomFixture extends Fixture
 
         $callerIdLoby = new CallerRoom();
         $callerIdLoby->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setCallerId('12341232');
         $manager->persist($callerIdLoby);
         $manager->flush();
@@ -704,19 +696,19 @@ class RoomFixture extends Fixture
         $predefined1 = new PredefinedLobbyMessages();
         $predefined1->setActive(true)
             ->setText('Bitte warten!')
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setPriority(0);
         $manager->persist($predefined1);
         $predefined2 = new PredefinedLobbyMessages();
         $predefined2->setActive(false)
             ->setText('Bitte warten/Disabled!')
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setPriority(1);
         $manager->persist($predefined2);
         $predefined3 = new PredefinedLobbyMessages();
         $predefined3->setActive(true)
             ->setText('Wir haben andere Themen!')
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setPriority(2);
 
         $manager->persist($predefined3);

--- a/src/DataFixtures/User.php
+++ b/src/DataFixtures/User.php
@@ -15,7 +15,7 @@ class User extends Fixture
         // USer mit Keycloak ID
         $user = new \App\Entity\User();
         $user->setEmail('test@local123.de');
-        $user->setCreatedAt(new \DateTime());
+        $user->setCreatedAt(new \DateTimeImmutable());
         $user->setKeycloakId(123456);
         $user->setFirstName('Test');
         $user->setLastName('User');
@@ -24,13 +24,13 @@ class User extends Fixture
         $user->setTimeZone('Europe/Berlin');
         $user->setUuid('lksdhflkjdsljflkjds');
         $user->setUsername('test@local123.de');
-        $user->setCreatedAt(new \DateTime());
+        $user->setCreatedAt(new \DateTimeImmutable());
         $manager->persist($user);
 
         // USer ohne Keycloak ID, also einfach eingeladen
         $user = new \App\Entity\User();
         $user->setEmail('testNoId@local.de');
-        $user->setCreatedAt(new \DateTime());
+        $user->setCreatedAt(new \DateTimeImmutable());
         $user->setFirstName('Test');
         $user->setLastName('User No ID');
         $user->setRegisterId(123456);

--- a/src/Entity/ApiKeys.php
+++ b/src/Entity/ApiKeys.php
@@ -16,7 +16,7 @@ class ApiKeys
     private $clientId;
     #[ORM\Column(type: 'text')]
     private $clientSecret;
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $createdAt;
     public function getId(): ?int
     {
@@ -42,11 +42,11 @@ class ApiKeys
 
         return $this;
     }
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
-    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 

--- a/src/Entity/CallerId.php
+++ b/src/Entity/CallerId.php
@@ -20,7 +20,7 @@ class CallerId
     private $user;
     #[ORM\Column(type: 'text')]
     private $callerId;
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $createdAt;
     #[ORM\OneToOne(targetEntity: CallerSession::class, inversedBy: 'caller', cascade: ['persist', 'remove'])]
     private $callerSession;
@@ -58,11 +58,11 @@ class CallerId
 
         return $this;
     }
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
-    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 

--- a/src/Entity/CallerRoom.php
+++ b/src/Entity/CallerRoom.php
@@ -17,7 +17,7 @@ class CallerRoom
     #[ORM\OneToOne(targetEntity: Rooms::class, inversedBy: 'callerRoom')]
     #[ORM\JoinColumn(nullable: false)]
     private $room;
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $createdAt;
     public function getId(): ?int
     {
@@ -43,11 +43,11 @@ class CallerRoom
 
         return $this;
     }
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
-    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 

--- a/src/Entity/CallerSession.php
+++ b/src/Entity/CallerSession.php
@@ -17,7 +17,7 @@ class CallerSession
     #[ORM\OneToOne(targetEntity: LobbyWaitungUser::class, inversedBy: 'callerSession', cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: true)]
     private $lobbyWaitingUser;
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $createdAt;
     #[ORM\Column(type: 'boolean')]
     private $authOk;
@@ -64,11 +64,11 @@ class CallerSession
 
         return $this;
     }
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
-    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 

--- a/src/Entity/CalloutSession.php
+++ b/src/Entity/CalloutSession.php
@@ -40,8 +40,8 @@ class CalloutSession
     #[ORM\JoinColumn(nullable: false)]
     private ?User $user = null;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private ?\DateTimeInterface $createdAt = null;
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private ?\DateTimeImmutable $createdAt = null;
 
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(nullable: false)]
@@ -88,12 +88,12 @@ class CalloutSession
         return $this;
     }
 
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
 
-    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 

--- a/src/Entity/Deputy.php
+++ b/src/Entity/Deputy.php
@@ -25,8 +25,8 @@ class Deputy
     #[ORM\Column(nullable: true)]
     private ?bool $isFromLdap = null;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private ?\DateTimeInterface $createdAt = null;
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private ?\DateTimeImmutable $createdAt = null;
 
 
     public function getId(): ?int
@@ -70,12 +70,12 @@ class Deputy
         return $this;
     }
 
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
 
-    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 

--- a/src/Entity/Documents.php
+++ b/src/Entity/Documents.php
@@ -32,9 +32,9 @@ class Documents implements \Serializable
     #[Assert\File(maxSize: "3M",maxSizeMessage: 'The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}',)]
     private $documentFile;
     /**
-     * @var \DateTime
+     * @var \DateTimeImmutable
      */
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $updatedAt;
 
     /**
@@ -51,7 +51,7 @@ class Documents implements \Serializable
     public function setDocumentFileName(?string $documentFileName): void
     {
         $this->documentFileName = $documentFileName;
-        $this->updatedAt = new \DateTime();
+        $this->updatedAt = new \DateTimeImmutable();
     }
 
     /**
@@ -71,17 +71,17 @@ class Documents implements \Serializable
     }
 
     /**
-     * @return \DateTime
+     * @return \DateTimeImmutable
      */
-    public function getUpdatedAt(): \DateTime
+    public function getUpdatedAt(): \DateTimeImmutable
     {
         return $this->updatedAt;
     }
 
     /**
-     * @param \DateTime $updatedAt
+     * @param \DateTimeImmutable $updatedAt
      */
-    public function setUpdatedAt(\DateTime $updatedAt): void
+    public function setUpdatedAt(\DateTimeImmutable $updatedAt): void
     {
         $this->updatedAt = $updatedAt;
     }

--- a/src/Entity/License.php
+++ b/src/Entity/License.php
@@ -19,7 +19,7 @@ class License
     private $licenseKey;
     #[ORM\Column(type: 'text')]
     private $license;
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $validUntil;
     #[ORM\Column(type: 'text')]
     private $url;
@@ -47,11 +47,11 @@ class License
 
         return $this;
     }
-    public function getValidUntil(): ?\DateTimeInterface
+    public function getValidUntil(): ?\DateTimeImmutable
     {
         return $this->validUntil;
     }
-    public function setValidUntil(\DateTimeInterface $validUntil): self
+    public function setValidUntil(\DateTimeImmutable $validUntil): self
     {
         $this->validUntil = $validUntil;
 

--- a/src/Entity/LobbyWaitungUser.php
+++ b/src/Entity/LobbyWaitungUser.php
@@ -19,7 +19,7 @@ class LobbyWaitungUser
     #[ORM\ManyToOne(targetEntity: Rooms::class, inversedBy: 'lobbyWaitungUsers')]
     #[ORM\JoinColumn(nullable: false)]
     private $room;
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $createdAt;
     #[ORM\Column(type: 'text')]
     private $uid;
@@ -59,11 +59,11 @@ class LobbyWaitungUser
 
         return $this;
     }
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
-    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 

--- a/src/Entity/Log.php
+++ b/src/Entity/Log.php
@@ -14,8 +14,8 @@ class Log
     #[ORM\Column]
     private ?int $id = null;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private ?\DateTimeInterface $createdAt = null;
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private ?\DateTimeImmutable $createdAt = null;
 
     #[ORM\Column(type: Types::TEXT)]
     private ?string $userName = null;
@@ -34,12 +34,12 @@ class Log
         return $this->id;
     }
 
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
 
-    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 

--- a/src/Entity/Notification.php
+++ b/src/Entity/Notification.php
@@ -19,7 +19,7 @@ class Notification
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'notifications')]
     #[ORM\JoinColumn(nullable: false)]
     private $user;
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $createdAt;
     #[ORM\Column(type: 'text', nullable: true)]
     private $url;
@@ -57,11 +57,11 @@ class Notification
 
         return $this;
     }
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
-    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 

--- a/src/Entity/PredefinedLobbyMessages.php
+++ b/src/Entity/PredefinedLobbyMessages.php
@@ -23,8 +23,8 @@ class PredefinedLobbyMessages
     #[ORM\Column(nullable: true)]
     private ?bool $active = null;
 
-    #[ORM\Column(type: Types::DATETIME_MUTABLE)]
-    private ?\DateTimeInterface $created_at = null;
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private ?\DateTimeImmutable $created_at = null;
 
     public function getId(): ?int
     {
@@ -67,12 +67,12 @@ class PredefinedLobbyMessages
         return $this;
     }
 
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->created_at;
     }
 
-    public function setCreatedAt(\DateTimeInterface $created_at): self
+    public function setCreatedAt(\DateTimeImmutable $created_at): self
     {
         $this->created_at = $created_at;
 

--- a/src/Entity/Repeat.php
+++ b/src/Entity/Repeat.php
@@ -23,7 +23,7 @@ class Repeat
     private $id;
     #[ORM\Column(type: 'integer', nullable: true)]
     private $repetation;
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $repeatUntil;
     #[ORM\OneToMany(targetEntity: Rooms::class, mappedBy: 'repeater')]
     private $rooms;
@@ -47,7 +47,7 @@ class Repeat
     private $RepeatMontly;
     #[ORM\Column(type: 'integer', nullable: true)]
     private $RepeatYearly;
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $startDate;
     #[ORM\OneToOne(targetEntity: Rooms::class, inversedBy: 'repeaterProtoype', cascade: ['persist', 'remove'])]
     #[ORM\JoinColumn(nullable: true)]
@@ -88,11 +88,11 @@ class Repeat
 
         return $this;
     }
-    public function getRepeatUntil(): ?\DateTimeInterface
+    public function getRepeatUntil(): ?\DateTimeImmutable
     {
         return $this->repeatUntil;
     }
-    public function setRepeatUntil(?\DateTimeInterface $repeatUntil): self
+    public function setRepeatUntil(?\DateTimeImmutable $repeatUntil): self
     {
         $this->repeatUntil = $repeatUntil;
 
@@ -236,11 +236,11 @@ class Repeat
 
         return $this;
     }
-    public function getStartDate(): ?\DateTimeInterface
+    public function getStartDate(): ?\DateTimeImmutable
     {
         return $this->startDate;
     }
-    public function setStartDate(\DateTimeInterface $startDate): self
+    public function setStartDate(\DateTimeImmutable $startDate): self
     {
         $this->startDate = $startDate;
 

--- a/src/Entity/RoomStatus.php
+++ b/src/Entity/RoomStatus.php
@@ -16,15 +16,15 @@ class RoomStatus
     private $id;
     #[ORM\Column(type: 'boolean')]
     private $created;
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $RoomCreatedAt;
     #[ORM\Column(type: 'boolean', nullable: true)]
     private $destroyed;
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $destroyedAt;
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $createdAt;
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $updatedAt;
     #[ORM\OneToMany(targetEntity: RoomStatusParticipant::class, mappedBy: 'roomStatus', orphanRemoval: true)]
     private $roomStatusParticipants;
@@ -51,21 +51,21 @@ class RoomStatus
 
         return $this;
     }
-    public function getRoomCreatedAt(): ?\DateTimeInterface
+    public function getRoomCreatedAt(): ?\DateTimeImmutable
     {
         return $this->RoomCreatedAt;
     }
-    public function setRoomCreatedAt(?\DateTimeInterface $RoomCreatedAt): self
+    public function setRoomCreatedAt(?\DateTimeImmutable $RoomCreatedAt): self
     {
         $this->RoomCreatedAt = $RoomCreatedAt;
 
         return $this;
     }
-    public function getRoomCreatedAtUTC(): ?\DateTimeInterface
+    public function getRoomCreatedAtUTC(): ?\DateTimeImmutable
     {
-        return new \DateTime($this->RoomCreatedAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
+        return new \DateTimeImmutable($this->RoomCreatedAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
     }
-    public function getRoomCreatedAtwithTimeZone(?User $user = null): ?\DateTimeInterface
+    public function getRoomCreatedAtwithTimeZone(?User $user = null): ?\DateTimeImmutable
     {
         $data = $this->getCreatedUtc();
         if (!$data) {
@@ -77,10 +77,10 @@ class RoomStatus
             if ($this->room && $this->room->getTimeZone()) {
                 $localTimezone = new \DateTimeZone($this->room->getTimeZone());
             } else {
-                $localTimezone = (new \DateTime())->getTimezone();
+                $localTimezone = (new \DateTimeImmutable())->getTimezone();
             }
         }
-        $data->setTimeZone($localTimezone);
+        $data = $data->setTimeZone($localTimezone);
         return $data;
     }
     public function getDestroyed(): ?bool
@@ -93,11 +93,11 @@ class RoomStatus
 
         return $this;
     }
-    public function getDestroyedAt(): ?\DateTimeInterface
+    public function getDestroyedAt(): ?\DateTimeImmutable
     {
         return $this->destroyedAt;
     }
-    public function getDestroyedAtwithTimeZone(?User $user = null): ?\DateTimeInterface
+    public function getDestroyedAtwithTimeZone(?User $user = null): ?\DateTimeImmutable
     {
         $data = $this->getDestroyedAtUTC();
         if (!$data) {
@@ -109,40 +109,40 @@ class RoomStatus
             if ($this->room && $this->room->getTimeZone()) {
                 $localTimezone = new \DateTimeZone($this->room->getTimeZone());
             } else {
-                $localTimezone = (new \DateTime())->getTimezone();
+                $localTimezone = (new \DateTimeImmutable())->getTimezone();
             }
         }
-        $data->setTimeZone($localTimezone);
+        $data = $data->setTimeZone($localTimezone);
         return $data;
     }
-    public function getDestroyedAtUTC(): ?\DateTimeInterface
+    public function getDestroyedAtUTC(): ?\DateTimeImmutable
     {
         if (!$this->destroyedAt) {
             return null;
         }
-        return new \DateTime($this->destroyedAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
+        return new \DateTimeImmutable($this->destroyedAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
     }
-    public function setDestroyedAt(?\DateTimeInterface $destroyedAt): self
+    public function setDestroyedAt(?\DateTimeImmutable $destroyedAt): self
     {
         $this->destroyedAt = $destroyedAt;
 
         return $this;
     }
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
-    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 
         return $this;
     }
-    public function getUpdatedAt(): ?\DateTimeInterface
+    public function getUpdatedAt(): ?\DateTimeImmutable
     {
         return $this->updatedAt;
     }
-    public function setUpdatedAt(\DateTimeInterface $updatedAt): self
+    public function setUpdatedAt(\DateTimeImmutable $updatedAt): self
     {
         $this->updatedAt = $updatedAt;
 
@@ -195,16 +195,16 @@ class RoomStatus
 
         return $this;
     }
-    public function getCreatedUtc(): ?\DateTimeInterface
+    public function getCreatedUtc(): ?\DateTimeImmutable
     {
-        return new \DateTime($this->RoomCreatedAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
+        return new \DateTimeImmutable($this->RoomCreatedAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
     }
-    public function getDestroyedUtc(): ?\DateTimeInterface
+    public function getDestroyedUtc(): ?\DateTimeImmutable
     {
         if ($this->destroyedAt) {
-            return new \DateTime($this->destroyedAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
+            return new \DateTimeImmutable($this->destroyedAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
         } else {
-            return new \DateTime($this->updatedAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
+            return new \DateTimeImmutable($this->updatedAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
         }
     }
 }

--- a/src/Entity/RoomStatusParticipant.php
+++ b/src/Entity/RoomStatusParticipant.php
@@ -12,9 +12,9 @@ class RoomStatusParticipant
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
     private $id;
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $enteredRoomAt;
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $leftRoomAt;
     #[ORM\Column(type: 'boolean')]
     private $inRoom;
@@ -31,11 +31,11 @@ class RoomStatusParticipant
     {
         return $this->id;
     }
-    public function getEnteredRoomAt(): ?\DateTimeInterface
+    public function getEnteredRoomAt(): ?\DateTimeImmutable
     {
         return $this->enteredRoomAt;
     }
-    public function getEnteredRoomAtwithTimeZone(?User $user): ?\DateTimeInterface
+    public function getEnteredRoomAtwithTimeZone(?User $user): ?\DateTimeImmutable
     {
         $data = $this->getEnteredRoomAtUTC();
         if (!$data) {
@@ -44,29 +44,29 @@ class RoomStatusParticipant
         if ($user && $user->getTimeZone()) {
             $localTimezone = new \DateTimeZone($user->getTimeZone());
         } else {
-            $localTimezone = (new \DateTime())->getTimezone();
+            $localTimezone = (new \DateTimeImmutable())->getTimezone();
         }
-        $data->setTimeZone($localTimezone);
+        $data = $data->setTimeZone($localTimezone);
         return $data;
     }
-    public function getEnteredRoomAtUTC(): ?\DateTimeInterface
+    public function getEnteredRoomAtUTC(): ?\DateTimeImmutable
     {
         if (!$this->enteredRoomAt) {
             return null;
         }
-        return new \DateTime($this->enteredRoomAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
+        return new \DateTimeImmutable($this->enteredRoomAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
     }
-    public function setEnteredRoomAt(\DateTimeInterface $enteredRoomAt): self
+    public function setEnteredRoomAt(\DateTimeImmutable $enteredRoomAt): self
     {
         $this->enteredRoomAt = $enteredRoomAt;
 
         return $this;
     }
-    public function getLeftRoomAt(): ?\DateTimeInterface
+    public function getLeftRoomAt(): ?\DateTimeImmutable
     {
         return $this->leftRoomAt;
     }
-    public function getLeftRoomAtwithTimeZone(?User $user): ?\DateTimeInterface
+    public function getLeftRoomAtwithTimeZone(?User $user): ?\DateTimeImmutable
     {
         $data = $this->getLeftRoomAtUTC();
         if (!$data) {
@@ -75,19 +75,19 @@ class RoomStatusParticipant
         if ($user && $user->getTimeZone()) {
             $localTimezone = new \DateTimeZone($user->getTimeZone());
         } else {
-            $localTimezone = (new \DateTime())->getTimezone();
+            $localTimezone = (new \DateTimeImmutable())->getTimezone();
         }
-        $data->setTimeZone($localTimezone);
+        $data = $data->setTimeZone($localTimezone);
         return $data;
     }
-    public function getLeftRoomAtUTC(): ?\DateTimeInterface
+    public function getLeftRoomAtUTC(): ?\DateTimeImmutable
     {
         if (!$this->leftRoomAt) {
             return null;
         }
-        return new \DateTime($this->leftRoomAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
+        return new \DateTimeImmutable($this->leftRoomAt->format('Y-m-d H:i:s'), new \DateTimeZone('utc'));
     }
-    public function setLeftRoomAt(?\DateTimeInterface $leftRoomAt): self
+    public function setLeftRoomAt(?\DateTimeImmutable $leftRoomAt): self
     {
         $this->leftRoomAt = $leftRoomAt;
 

--- a/src/Entity/Rooms.php
+++ b/src/Entity/Rooms.php
@@ -19,9 +19,9 @@ class Rooms
     private $id;
     #[ORM\Column(type: 'text')]
     private $name;
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $start;
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $enddate;
     #[ORM\ManyToMany(targetEntity: User::class, inversedBy: 'rooms')]
     #[Ignore]
@@ -95,9 +95,9 @@ class Rooms
     private $totalOpenRoomsOpenTime = 30;
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     private $timeZone;
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $startUtc;
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $endDateUtc;
     #[ORM\ManyToMany(targetEntity: User::class, mappedBy: 'favorites')]
     private $favoriteUsers;
@@ -213,7 +213,7 @@ class Rooms
                 $srcTz ?? $this->start->getTimezone()
             );
             $utc = $dt->setTimezone(new \DateTimeZone('UTC'));
-            $this->startUtc = \DateTime::createFromImmutable($utc);
+            $this->startUtc = $utc;
             $this->startTimestamp = $utc->getTimestamp();
         } else {
             $this->startUtc = null;
@@ -227,7 +227,7 @@ class Rooms
                 $srcTz ?? $this->enddate->getTimezone()
             );
             $utc = $dt->setTimezone(new \DateTimeZone('UTC'));
-            $this->endDateUtc = \DateTime::createFromImmutable($utc);
+            $this->endDateUtc = $utc;
             $this->endTimestamp = $utc->getTimestamp();
         } else {
             $this->endDateUtc = null;
@@ -252,25 +252,25 @@ class Rooms
         return $this;
     }
 
-    public function getStart(): ?\DateTimeInterface
+    public function getStart(): ?\DateTimeImmutable
     {
 
         return $this->start;
     }
 
-    public function setStart(?\DateTimeInterface $start): self
+    public function setStart(?\DateTimeImmutable $start): self
     {
         $this->start = $start;
         $this->setUTCTime();
         return $this;
     }
 
-    public function getEnddate(): ?\DateTimeInterface
+    public function getEnddate(): ?\DateTimeImmutable
     {
         return $this->enddate;
     }
 
-    public function setEnddate(?\DateTimeInterface $enddate): self
+    public function setEnddate(?\DateTimeImmutable $enddate): self
     {
         $this->enddate = $enddate;
         $this->setUTCTime();
@@ -759,49 +759,49 @@ class Rooms
         }
     }
 
-    public function getStartwithTimeZone(?User $user): ?\DateTimeInterface
+    public function getStartwithTimeZone(?User $user): ?\DateTimeImmutable
     {
         if ($this->timeZone && $user && $user->getTimeZone()) {
-            $data = new \DateTime($this->start->format('Y-m-d H:i:s'), new \DateTimeZone($this->timeZone));
+            $data = new \DateTimeImmutable($this->start->format('Y-m-d H:i:s'), new \DateTimeZone($this->timeZone));
             $laTimezone = new \DateTimeZone($user->getTimeZone());
-            $data->setTimezone($laTimezone);
+            $data = $data->setTimezone($laTimezone);
             return $data;
         } else {
             return $this->start;
         }
     }
 
-    public function getEndwithTimeZone(?User $user): ?\DateTimeInterface
+    public function getEndwithTimeZone(?User $user): ?\DateTimeImmutable
     {
         if ($this->timeZone && $user && $user->getTimeZone()) {
-            $data = new \DateTime($this->enddate->format('Y-m-d H:i:s'), new \DateTimeZone($this->timeZone));
+            $data = new \DateTimeImmutable($this->enddate->format('Y-m-d H:i:s'), new \DateTimeZone($this->timeZone));
             $laTimezone = new \DateTimeZone($user->getTimeZone());
-            $data->setTimezone($laTimezone);
+            $data = $data->setTimezone($laTimezone);
             return $data;
         } else {
             return $this->enddate;
         }
     }
 
-    public function getStartUtc(): ?\DateTimeInterface
+    public function getStartUtc(): ?\DateTimeImmutable
     {
-        return $this->startUtc ? new \DateTime($this->startUtc->format('Y-m-d H:i:s'), new \DateTimeZone('utc')) : null;
+        return $this->startUtc ? new \DateTimeImmutable($this->startUtc->format('Y-m-d H:i:s'), new \DateTimeZone('utc')) : null;
     }
 
 
-    public function setStartUtc(?\DateTimeInterface $startUtc): self
+    public function setStartUtc(?\DateTimeImmutable $startUtc): self
     {
         $this->startUtc = $startUtc;
 
         return $this;
     }
 
-    public function getEndDateUtc(): ?\DateTimeInterface
+    public function getEndDateUtc(): ?\DateTimeImmutable
     {
-        return $this->endDateUtc ? new \DateTime($this->endDateUtc->format('Y-m-d H:i:s'), new \DateTimeZone('utc')) : null;
+        return $this->endDateUtc ? new \DateTimeImmutable($this->endDateUtc->format('Y-m-d H:i:s'), new \DateTimeZone('utc')) : null;
     }
 
-    public function setEndDateUtc(?\DateTimeInterface $endDateUtc): self
+    public function setEndDateUtc(?\DateTimeImmutable $endDateUtc): self
     {
         $this->endDateUtc = $endDateUtc;
 

--- a/src/Entity/SchedulingTime.php
+++ b/src/Entity/SchedulingTime.php
@@ -14,7 +14,7 @@ class SchedulingTime
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
     private $id;
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $time;
     #[ORM\ManyToOne(targetEntity: Scheduling::class, inversedBy: 'schedulingTimes')]
     #[ORM\JoinColumn(nullable: false)]
@@ -32,11 +32,11 @@ class SchedulingTime
     {
         return $this->id;
     }
-    public function getTime(): ?\DateTimeInterface
+    public function getTime(): ?\DateTimeImmutable
     {
         return $this->time;
     }
-    public function setTime(\DateTimeInterface $time): self
+    public function setTime(\DateTimeImmutable $time): self
     {
         $this->time = $time;
 
@@ -79,14 +79,14 @@ class SchedulingTime
 
         return $this;
     }
-    public function getTimeWithTimeZone(User $user): ?\DateTimeInterface
+    public function getTimeWithTimeZone(User $user): ?\DateTimeImmutable
     {
         $timeZone = $this->scheduling->getRoom()->getTimeZone() ? new \DateTimeZone($this->scheduling->getRoom()->getTimeZone()) : null;
-        $time = new \DateTime($this->time->format('Y-m-d H:i:s'), $timeZone);
+        $time = new \DateTimeImmutable($this->time->format('Y-m-d H:i:s'), $timeZone);
         $usrTimeZone = $user->getTimeZone() ? new \DateTimeZone($user->getTimeZone()) : null;
         if ($timeZone) {
             if ($usrTimeZone) {
-                $time->setTimezone($usrTimeZone);
+                $time = $time->setTimezone($usrTimeZone);
             }
         }
         return $time;

--- a/src/Entity/Server.php
+++ b/src/Entity/Server.php
@@ -80,7 +80,7 @@ class Server
      */
     #[ORM\OneToOne(targetEntity: Documents::class, cascade: ['persist', 'remove'])]
     private $serverBackgroundImage;
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $updatedAt;
 
     #[ORM\Column(type: Types::TEXT, nullable: true)]
@@ -653,12 +653,12 @@ class Server
         return $this;
     }
 
-    public function getUpdatedAt(): ?\DateTimeInterface
+    public function getUpdatedAt(): ?\DateTimeImmutable
     {
         return $this->updatedAt;
     }
 
-    public function setUpdatedAt(?\DateTimeInterface $updatedAt): self
+    public function setUpdatedAt(?\DateTimeImmutable $updatedAt): self
     {
         $this->updatedAt = $updatedAt;
 

--- a/src/Entity/Star.php
+++ b/src/Entity/Star.php
@@ -20,7 +20,7 @@ class Star
     private $star;
     #[ORM\Column(type: 'text', nullable: true)]
     private $comment;
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $createdAt;
 
     #[ORM\Column(type: Types::TEXT, nullable: true)]
@@ -62,11 +62,11 @@ class Star
 
         return $this;
     }
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
-    public function setCreatedAt(?\DateTimeInterface $createdAt): self
+    public function setCreatedAt(?\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -31,11 +31,11 @@ class User extends BaseUser
     private $email;
     #[ORM\Column(type: 'text', nullable: true)]
     private $keycloakId;
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $createdAt;
     #[ORM\Column(type: 'text', nullable: true)]
     private $username;
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $lastLogin;
     #[ORM\Column(type: 'text', nullable: true)]
     private $firstName;
@@ -100,7 +100,7 @@ class User extends BaseUser
      */
     #[ORM\OneToOne(targetEntity: Documents::class, cascade: ['persist', 'remove'])]
     private $profilePicture;
-    #[ORM\Column(type: 'datetime', nullable: true)]
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
     private $updatedAt;
     #[ORM\OneToMany(targetEntity: CallerId::class, mappedBy: 'user', cascade: ['remove'])]
     private $callerIds;
@@ -222,12 +222,12 @@ class User extends BaseUser
         return $this;
     }
 
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
 
-    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 
@@ -246,12 +246,12 @@ class User extends BaseUser
         return $this;
     }
 
-    public function getLastLogin(): ?\DateTimeInterface
+    public function getLastLogin(): ?\DateTimeImmutable
     {
         return $this->lastLogin;
     }
 
-    public function setLastLogin(?\DateTimeInterface $lastLogin): self
+    public function setLastLogin(?\DateTimeImmutable $lastLogin): self
     {
         $this->lastLogin = $lastLogin;
 
@@ -922,12 +922,12 @@ class User extends BaseUser
         return $this;
     }
 
-    public function getUpdatedAt(): ?\DateTimeInterface
+    public function getUpdatedAt(): ?\DateTimeImmutable
     {
         return $this->updatedAt;
     }
 
-    public function setUpdatedAt(?\DateTimeInterface $updatedAt): self
+    public function setUpdatedAt(?\DateTimeImmutable $updatedAt): self
     {
         $this->updatedAt = $updatedAt;
 

--- a/src/Entity/Waitinglist.php
+++ b/src/Entity/Waitinglist.php
@@ -18,7 +18,7 @@ class Waitinglist
     #[ORM\ManyToOne(targetEntity: Rooms::class, inversedBy: 'waitinglists')]
     #[ORM\JoinColumn(nullable: false)]
     private $room;
-    #[ORM\Column(type: 'datetime')]
+    #[ORM\Column(type: 'datetime_immutable')]
     private $createdAt;
     public function getId(): ?int
     {
@@ -44,11 +44,11 @@ class Waitinglist
 
         return $this;
     }
-    public function getCreatedAt(): ?\DateTimeInterface
+    public function getCreatedAt(): ?\DateTimeImmutable
     {
         return $this->createdAt;
     }
-    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    public function setCreatedAt(\DateTimeImmutable $createdAt): self
     {
         $this->createdAt = $createdAt;
 

--- a/src/Form/Type/RoomType.php
+++ b/src/Form/Type/RoomType.php
@@ -57,7 +57,7 @@ class RoomType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
 
-        $time = (new \DateTime())->getTimestamp();
+        $time = (new \DateTimeImmutable())->getTimestamp();
         $room = $options['data'];
         $during = false;
         if ($room->getStartTimestamp() && $room->getStartTimestamp() <= $time && !$room->getRepeaterProtoype()) {
@@ -92,7 +92,7 @@ class RoomType extends AbstractType
         $builder
             ->add('name', TextType::class, ['disabled' => $during, 'required' => true, 'label' => 'label.konferenzName', 'translation_domain' => 'form'])
             ->add('agenda', TextareaType::class, ['disabled' => $during, 'required' => false, 'label' => 'label.agenda', 'translation_domain' => 'form'])
-            ->add('start', DateTimeType::class, ['required' => true, 'attr' => ['data-minDate' => $options['minDate'], 'class' => 'flatpickr', 'placeholder' => 'placeholder.chooseTime'], 'label' => 'label.start', 'translation_domain' => 'form', 'widget' => 'single_text'])
+            ->add('start', DateTimeType::class, ['input' => 'datetime_immutable', 'required' => true, 'attr' => ['data-minDate' => $options['minDate'], 'class' => 'flatpickr', 'placeholder' => 'placeholder.chooseTime'], 'label' => 'label.start', 'translation_domain' => 'form', 'widget' => 'single_text'])
             ->add(
                 'duration',
                 ChoiceType::class,

--- a/src/Form/Type/SchedulerType.php
+++ b/src/Form/Type/SchedulerType.php
@@ -9,7 +9,7 @@ use App\Entity\User;
 use App\Repository\TagRepository;
 use App\Service\Theme\ThemeService;
 use App\Util\InputSettings;
-use DateTime;
+use DateTimeImmutable;
 use Psr\Log\LoggerInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
@@ -52,7 +52,7 @@ class SchedulerType extends AbstractType
             $durations[sprintf(self::DURATION_LABEL_FORMAT, $i)] = $i;
         }
 
-        $time = (new DateTime())->getTimestamp();
+        $time = (new DateTimeImmutable())->getTimestamp();
         $room = $options['data'];
         $during = false;
         if ($room->getStartTimestamp() && $room->getStartTimestamp() < $time && !$room->getRepeaterProtoype()) {

--- a/src/Migrations/Version20260910221843.php
+++ b/src/Migrations/Version20260910221843.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Records the (DC2Type:datetime_immutable) type hint on every DATETIME column that
+ * was converted from the mutable `datetime` DBAL type to `datetime_immutable`.
+ *
+ * The underlying SQL type stays DATETIME; only the Doctrine type-hint comment changes,
+ * so no data is read or rewritten.
+ */
+final class Version20260910221843 extends AbstractMigration
+{
+    private const COMMENT = '(DC2Type:datetime_immutable)';
+
+    /** @var array<string, list<string>> */
+    private const COLUMNS = [
+        'rooms' => ['start', 'enddate', 'start_utc', 'end_date_utc'],
+        'fos_user' => ['created_at', 'last_login', 'updated_at'],
+        'room_status' => ['room_created_at', 'destroyed_at', 'created_at', 'updated_at'],
+        'room_status_participant' => ['entered_room_at', 'left_room_at'],
+        'repeat' => ['repeat_until', 'start_date'],
+        'api_keys' => ['created_at'],
+        'caller_id' => ['created_at'],
+        'caller_room' => ['created_at'],
+        'caller_session' => ['created_at'],
+        'callout_session' => ['created_at'],
+        'deputy' => ['created_at'],
+        'documents' => ['updated_at'],
+        'license' => ['valid_until'],
+        'lobby_waitung_user' => ['created_at'],
+        'log' => ['created_at'],
+        'notification' => ['created_at'],
+        'predefined_lobby_messages' => ['created_at'],
+        'scheduling_time' => ['time'],
+        'server' => ['updated_at'],
+        'star' => ['created_at'],
+        'waitinglist' => ['created_at'],
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Add (DC2Type:datetime_immutable) comment to converted DATETIME columns';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach (self::COLUMNS as $tableName => $columns) {
+            $table = $schema->getTable($tableName);
+            foreach ($columns as $column) {
+                $table->modifyColumn($column, ['comment' => self::COMMENT]);
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach (self::COLUMNS as $tableName => $columns) {
+            $table = $schema->getTable($tableName);
+            foreach ($columns as $column) {
+                $table->modifyColumn($column, ['comment' => null]);
+            }
+        }
+    }
+}

--- a/src/Repository/LobbyWaitungUserRepository.php
+++ b/src/Repository/LobbyWaitungUserRepository.php
@@ -47,7 +47,7 @@ class LobbyWaitungUserRepository extends ServiceEntityRepository
         ;
     }
     */
-    public function findOldLobbyWaitinguser(\DateTime $oldestDate)
+    public function findOldLobbyWaitinguser(\DateTimeImmutable $oldestDate)
     {
         return $this->createQueryBuilder('l')
             ->andWhere('l.createdAt < :oldest')

--- a/src/Repository/RoomsRepository.php
+++ b/src/Repository/RoomsRepository.php
@@ -60,8 +60,8 @@ class RoomsRepository extends ServiceEntityRepository
     */
     public function findRoomsInFuture(User $user)
     {
-        $now = new \DateTime('now', $this->timeZoneService->getTimeZone($user));
-        $now->setTimezone(new \DateTimeZone('utc'));
+        $now = new \DateTimeImmutable('now', $this->timeZoneService->getTimeZone($user));
+        $now = $now->setTimezone(new \DateTimeZone('utc'));
         $qb = $this->createQueryBuilder('r');
         return $qb->innerJoin('r.user', 'user')
             ->leftJoin('user.managerElement', 'managerelement')
@@ -84,8 +84,8 @@ class RoomsRepository extends ServiceEntityRepository
 
     public function findRoomsInPast(User $user, $offset)
     {
-        $now = new \DateTime('now', $this->timeZoneService->getTimeZone($user));
-        $now->setTimezone(new \DateTimeZone('utc'));
+        $now = new \DateTimeImmutable('now', $this->timeZoneService->getTimeZone($user));
+        $now = $now->setTimezone(new \DateTimeZone('utc'));
         $qb = $this->createQueryBuilder('r');
         $rooms = $qb->select('r')
             ->addSelect('server')
@@ -134,7 +134,7 @@ class RoomsRepository extends ServiceEntityRepository
 
     public function findRoomsForUser(User $user)
     {
-        $now = new \DateTime();
+        $now = new \DateTimeImmutable();
         $qb = $this->createQueryBuilder('r');
         return $qb->innerJoin('r.user', 'user')
             ->leftJoin('user.managerElement', 'managerelement')
@@ -156,8 +156,8 @@ class RoomsRepository extends ServiceEntityRepository
     public function findRuningRooms(User $user)
     {
 
-        $now = new \DateTime('now', $this->timeZoneService->getTimeZone($user));
-        $now->setTimezone(new \DateTimeZone('utc'));
+        $now = new \DateTimeImmutable('now', $this->timeZoneService->getTimeZone($user));
+        $now = $now->setTimezone(new \DateTimeZone('utc'));
         $qb = $this->createQueryBuilder('r');
         return $qb->innerJoin('r.user', 'user')
             ->leftJoin('user.managerElement', 'managerelement')
@@ -181,9 +181,9 @@ class RoomsRepository extends ServiceEntityRepository
 
     public function findTodayRooms(User $user)
     {
-        $now = new \DateTime('now', new \DateTimeZone('utc'));
-        $midnight = new \DateTime('now', new \DateTimeZone('utc'));
-        $midnight->setTime(23, 59, 59);
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('utc'));
+        $midnight = new \DateTimeImmutable('now', new \DateTimeZone('utc'));
+        $midnight = $midnight->setTime(23, 59, 59);
         $qb = $this->createQueryBuilder('r');
 
         return $qb
@@ -265,7 +265,7 @@ class RoomsRepository extends ServiceEntityRepository
 
     public function findRoomsFutureAndPast(User $user, $timeBack)
     {
-        $now = (new \DateTime('now', new \DateTimeZone('utc')))->modify($timeBack);
+        $now = (new \DateTimeImmutable('now', new \DateTimeZone('utc')))->modify($timeBack);
         $qb = $this->createQueryBuilder('r');
         return $qb->innerJoin('r.user', 'user')
             ->leftJoin('user.managerElement', 'managerelement')
@@ -288,8 +288,8 @@ class RoomsRepository extends ServiceEntityRepository
 
     public function findRoomsForDashboard(User $user)
     {
-        $now = new \DateTime('now', $this->timeZoneService->getTimeZone($user));
-        $now->setTimezone(new \DateTimeZone('utc'));
+        $now = new \DateTimeImmutable('now', $this->timeZoneService->getTimeZone($user));
+        $now = $now->setTimezone(new \DateTimeZone('utc'));
 
         $qb = $this->createQueryBuilder('r');
         $qb->select('r')
@@ -506,15 +506,15 @@ class RoomsRepository extends ServiceEntityRepository
             ->andWhere('server = :server')
             ->andWhere('r.startUtc BETWEEN :now AND :future')
             ->setParameter('server', $server)
-            ->setParameter('now', new \DateTime('now', new \DateTimeZone('utc')))
-            ->setParameter('future', new \DateTime("+$minutes minutes", new \DateTimeZone('utc')))
+            ->setParameter('now', new \DateTimeImmutable('now', new \DateTimeZone('utc')))
+            ->setParameter('future', new \DateTimeImmutable("+$minutes minutes", new \DateTimeZone('utc')))
             ->getQuery()
             ->getResult();
     }
 
     public function findRoomsnotInPast()
     {
-        $now = (new \DateTime('now'))->getTimestamp();
+        $now = (new \DateTimeImmutable('now'))->getTimestamp();
         $qb = $this->createQueryBuilder('r');
         return $qb
             ->andWhere(

--- a/src/Security/KeycloakAuthenticator.php
+++ b/src/Security/KeycloakAuthenticator.php
@@ -119,7 +119,7 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements Authenticatio
                         if (!$username) {
                             $username = $email;
                         }
-                        $existingUser->setLastLogin(new \DateTime());
+                        $existingUser->setLastLogin(new \DateTimeImmutable());
                         $existingUser->setEmail($email);
                         $existingUser->setFirstName($firstName);
                         $existingUser->setLastName($lastName);
@@ -142,7 +142,7 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements Authenticatio
                             $username = $email;
                         }
                         $existingUser->setKeycloakId($id);
-                        $existingUser->setLastLogin(new \DateTime());
+                        $existingUser->setLastLogin(new \DateTimeImmutable());
                         $existingUser->setEmail($email);
                         $existingUser->setFirstName($firstName);
                         $existingUser->setLastName($lastName);
@@ -162,7 +162,7 @@ class KeycloakAuthenticator extends OAuth2Authenticator implements Authenticatio
                         }
                         $newUser = $this->userCreatorService->createUser($email, $username, $firstName, $lastName);
                         $newUser
-                            ->setLastLogin(new \DateTime())
+                            ->setLastLogin(new \DateTimeImmutable())
                             ->setKeycloakId($id)
                             ->setGroups($groups);
                         $newUser->setIndexer($this->indexer->indexUser($newUser));

--- a/src/Service/AdminService.php
+++ b/src/Service/AdminService.php
@@ -29,14 +29,13 @@ class AdminService
 
 
         $chart = [];
-        $firstDate = new \DateTime();
-        $firstDate = date_modify($firstDate, '-30 days');
-        $lastDate = new \DateTime();
-        $lastDate = date_modify($lastDate, '+30 days');
+        $firstDate = new \DateTimeImmutable();
+        $firstDate = $firstDate->modify('-30 days');
+        $lastDate = new \DateTimeImmutable();
+        $lastDate = $lastDate->modify('+30 days');
         $participants = $this->em->getRepository(RoomStatusParticipant::class)->findParticipantsByServer($server, $firstDate, $lastDate);
         for ($x = 0; $x <= 60; $x++) {
-            $d = clone $firstDate;
-            $date = date_modify($d, '+' . $x . 'days');
+            $date = $firstDate->modify('+' . $x . 'days');
 
             $chart[$date->format('Ymd')]['date'] = $date;
             $chart[$date->format('Ymd')]['participants'] = 0;

--- a/src/Service/Callout/CalloutService.php
+++ b/src/Service/Callout/CalloutService.php
@@ -93,7 +93,7 @@ class CalloutService
         $callout = new CalloutSession();
         $callout->setUser($user)
             ->setRoom($rooms)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setInvitedFrom($inviter)
             ->setUid(md5(uniqid()))
             ->setState(CalloutSession::$INITIATED)

--- a/src/Service/Callout/CalloutSessionAPIService.php
+++ b/src/Service/Callout/CalloutSessionAPIService.php
@@ -53,13 +53,13 @@ class CalloutSessionAPIService
         $this->logger->debug('lastdialed',
             [
                 $calloutSession->getLastDialed(),
-                (new \DateTime())->format('U'),
-                (intval((new \DateTime())->format('U')) - $calloutSession->getLastDialed())
+                (new \DateTimeImmutable())->format('U'),
+                (intval((new \DateTimeImmutable())->format('U')) - $calloutSession->getLastDialed())
             ]);
-        if ($calloutSession->getLastDialed() && ((intval((new \DateTime())->format('U')) - $calloutSession->getLastDialed()) < $this->parameterBag->get('CALLOUT_WAITING_TIME'))) {
+        if ($calloutSession->getLastDialed() && ((intval((new \DateTimeImmutable())->format('U')) - $calloutSession->getLastDialed()) < $this->parameterBag->get('CALLOUT_WAITING_TIME'))) {
             return null;
         } else {
-            $calloutSession->setLastDialed((new \DateTime())->format('U'));
+            $calloutSession->setLastDialed((new \DateTimeImmutable())->format('U'));
             $this->entityManager->persist($calloutSession);
             $this->entityManager->flush();
         }

--- a/src/Service/CleanupLobbyService.php
+++ b/src/Service/CleanupLobbyService.php
@@ -16,7 +16,7 @@ class CleanupLobbyService
 
     public function cleanUp($maxOld = 72)
     {
-        $date = (new \DateTime())->modify('-' . $maxOld . 'hours');
+        $date = (new \DateTimeImmutable())->modify('-' . $maxOld . 'hours');
         $oldestData = $this->em->getRepository(LobbyWaitungUser::class)->findOldLobbyWaitinguser($date);
         foreach ($oldestData as $data) {
             if ($data->getCallerSession()) {

--- a/src/Service/DashboardService.php
+++ b/src/Service/DashboardService.php
@@ -9,8 +9,8 @@ class DashboardService
 {
     public function categorizeRooms(array $rooms, User $user): array
     {
-        $nowUtc = new \DateTime('now', new \DateTimeZone('utc'));
-        $todayEndUtc = (new \DateTime('now', new \DateTimeZone('utc')))->setTime(23, 59, 59);
+        $nowUtc = new \DateTimeImmutable('now', new \DateTimeZone('utc'));
+        $todayEndUtc = (new \DateTimeImmutable('now', new \DateTimeZone('utc')))->setTime(23, 59, 59);
 
         $roomsFuture = [];
         $roomsNow = [];
@@ -62,7 +62,7 @@ class DashboardService
 
     public function getRoomClosedForStartMap(array $rooms, User $user, array $roomStatusOpenMap): array
     {
-        $now = new \DateTime('now', new \DateTimeZone('utc'));
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('utc'));
         $result = [];
         foreach ($rooms as $room) {
             if (isset($roomStatusOpenMap[$room->getId()])) {
@@ -77,7 +77,7 @@ class DashboardService
             $start = $room->getStartUtc();
             $end = $room->getEndDateUtc();
             if ($start && $end) {
-                $startWindow = (clone $start)->modify('-30min');
+                $startWindow = $start->modify('-30min');
                 if ($startWindow > $now || $end < $now) {
                     $result[$room->getId()] = sprintf(
                         'Der Beitritt ist nur von %s bis %s möglich',

--- a/src/Service/Deputy/DeputyService.php
+++ b/src/Service/Deputy/DeputyService.php
@@ -36,7 +36,7 @@ class DeputyService
             $dep = new Deputy();
             $dep->setManager($manager);
             $dep->setDeputy($deputy);
-            $dep->setCreatedAt(new \DateTime());
+            $dep->setCreatedAt(new \DateTimeImmutable());
             $dep->setIsFromLdap(false);
             $this->entityManager->persist($dep);
             $this->entityManager->flush();

--- a/src/Service/FavoriteService.php
+++ b/src/Service/FavoriteService.php
@@ -36,7 +36,7 @@ class FavoriteService
     public function cleanFavorites(User $user)
     {
         $favorites = $user->getFavorites();
-        $now = (new \DateTime())->setTimezone(new \DateTimeZone('utc'));
+        $now = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone('utc'));
         $changed = false;
         foreach ($favorites as $favorite) {
             if (!$favorite->getUser()->contains($user)

--- a/src/Service/IcsService.php
+++ b/src/Service/IcsService.php
@@ -218,7 +218,7 @@ class IcsService
     }
 
     /** Convert DateTimeInterface|string to UTC Z format. */
-    public function toUtcZ(\DateTimeInterface|string $value): string
+    public function toUtcZ(\DateTimeImmutable|string $value): string
     {
         if ($value instanceof \DateTimeInterface) {
             $dt = (new \DateTimeImmutable($value->format('c')))->setTimezone(new \DateTimeZone('UTC'));

--- a/src/Service/JoinService.php
+++ b/src/Service/JoinService.php
@@ -64,15 +64,15 @@ class JoinService
                 $type = 'b';
             }
             $start = null;
-            $now =  new \DateTime('now', new \DateTimeZone('utc'));
+            $now =  new \DateTimeImmutable('now', new \DateTimeZone('utc'));
             $endDate = null;
             if(!$room->getPersistantRoom()){
 
-                $start = (clone $room->getStartUtc())->modify('-30min');
-                $endDate = clone $room->getEndDateUtc();
+                $start = $room->getStartUtc()->modify('-30min');
+                $endDate = $room->getEndDateUtc();
 
-                $startPrint = $room->getTimeZone()?clone ($room->getStartUtc())->setTimeZone(new \DateTimeZone($room->getTimeZone())):$room->getStart();
-                $startPrint->modify('-30min');
+                $startPrint = $room->getTimeZone() ? $room->getStartUtc()->setTimeZone(new \DateTimeZone($room->getTimeZone())):$room->getStart();
+                $startPrint = $startPrint->modify('-30min');
                 $endPrint = $room->getTimeZone()?$room->getEndDateUtc()->setTimeZone(new \DateTimeZone($room->getTimeZone())):$room->getEnddate();
 
             }
@@ -163,7 +163,7 @@ class JoinService
             $res = new RedirectResponse($url);
         }
 
-        $res->headers->setCookie(new Cookie('name', $name, (new \DateTime())->modify('+365 days')));
+        $res->headers->setCookie(new Cookie('name', $name, (new \DateTimeImmutable())->modify('+365 days')));
         return $res;
     }
 
@@ -178,7 +178,7 @@ class JoinService
     {
         $url = $this->urlGenerator->generate('room_waiting', array('name' => $name, 'uid' => $room->getUid(), 'type' => $type));
         $res = new RedirectResponse(($url));
-        $res->headers->setCookie(new Cookie('name', $name, (new \DateTime())->modify('+365 days')));
+        $res->headers->setCookie(new Cookie('name', $name, (new \DateTimeImmutable())->modify('+365 days')));
         return $res;
     }
 }

--- a/src/Service/LicenseService.php
+++ b/src/Service/LicenseService.php
@@ -51,7 +51,7 @@ class LicenseService
 
         $license = new License();
         $license->setUrl($licenseArr['server_url']);
-        $license->setValidUntil((new \DateTime($licenseArr['valid_until']))->setTime(23, 59, 59));
+        $license->setValidUntil((new \DateTimeImmutable($licenseArr['valid_until']))->setTime(23, 59, 59));
         $license->setLicenseKey($licenseArr['license_key']);
         $license->setLicense($licenseString);
 

--- a/src/Service/Lobby/CreateLobbyUserService.php
+++ b/src/Service/Lobby/CreateLobbyUserService.php
@@ -30,7 +30,7 @@ class CreateLobbyUserService
             $lobbyUser->setType($type);
             $lobbyUser->setUser($user);
             $lobbyUser->setRoom($room);
-            $lobbyUser->setCreatedAt(new \DateTime());
+            $lobbyUser->setCreatedAt(new \DateTimeImmutable());
             $lobbyUser->setUid(md5(uniqid()));
             $lobbyUser->setShowName($user->getFormatedName($this->parameterBag->get('laf_showNameInConference')));
 

--- a/src/Service/NewRoomService.php
+++ b/src/Service/NewRoomService.php
@@ -132,7 +132,7 @@ class NewRoomService
                     JsonEncoder::FORMAT,
                     [AbstractNormalizer::IGNORED_ATTRIBUTES => $exclude])),
             );
-            $log->setCreatedAt(new \DateTime())
+            $log->setCreatedAt(new \DateTimeImmutable())
                 ->setUserName($myUser->getUid())
                 ->setMessage(json_encode($message))
                 ->setUser($myUser)

--- a/src/Service/PexelService.php
+++ b/src/Service/PexelService.php
@@ -30,7 +30,7 @@ class PexelService
                         $item->expiresAfter(intval($this->parameterBag->get('laF_pexel_refresh_time')));
 
                         $s = [];
-                        $hour = (new \DateTime())->format('H');
+                        $hour = (new \DateTimeImmutable())->format('H');
                         if ($hour < 7) {
                             $s = ['night', 'northern lights'];
                         } elseif ($hour < 9) {

--- a/src/Service/RecordingService.php
+++ b/src/Service/RecordingService.php
@@ -108,7 +108,7 @@ class RecordingService
         // Datenbankeintrag erstellen
         $uploadedFileEntity = new UploadedRecording();
         $uploadedFileEntity->setFilename($fileName)
-            ->setDisplayName((new \DateTime())->format('d.m.Y H:i') . '.mp4')
+            ->setDisplayName((new \DateTimeImmutable())->format('d.m.Y H:i') . '.mp4')
             ->setRoom($room)
             ->setCreatedAt(new \DateTimeImmutable())
             ->setType('video/mp4')

--- a/src/Service/ReminderService.php
+++ b/src/Service/ReminderService.php
@@ -25,8 +25,8 @@ class ReminderService
     public function sendReminder($filter)
     {
         set_time_limit(600);
-        $now = (new \DateTime())->setTimezone(new \DateTimeZone('utc'));
-        $now10 = (clone $now)->modify('+ 10 minutes');
+        $now = (new \DateTimeImmutable())->setTimezone(new \DateTimeZone('utc'));
+        $now10 = $now->modify('+ 10 minutes');
 
         $qb = $this->em->getRepository(Rooms::class)->createQueryBuilder('rooms');
         $qb->where('rooms.startUtc > :now')

--- a/src/Service/RepeaterService.php
+++ b/src/Service/RepeaterService.php
@@ -126,14 +126,13 @@ class RepeaterService
         //hier bauen wir alle X tage einen neuenRoom
         $start = $repeat->getStartDate();
         $prototype = $this->em->getRepository(Rooms::class)->find($repeat->getPrototyp()->getId());
-        $start->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
+        $start = $start->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
 
         for ($i = 0; $i < $repeat->getRepetation(); $i++) {
-            $startTmp = clone $start;
-            $room = $this->createClonedRoom($prototype, $repeat, $startTmp);
+            $room = $this->createClonedRoom($prototype, $repeat, $start);
             $repeat->addRoom($room);
             $this->em->persist($room);
-            $start->modify('+' . $repeat->getRepeaterDays() . ' days');
+            $start = $start->modify('+' . $repeat->getRepeaterDays() . ' days');
         }
         $this->em->persist($repeat);
         $this->em->flush();
@@ -150,14 +149,13 @@ class RepeaterService
 
         $start = $repeat->getStartDate();
         $prototype = $repeat->getPrototyp();
-        $start->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
+        $start = $start->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
 
         for ($i = 0; $i < $repeat->getRepetation(); $i++) {
-            $startTmp = clone $start;
-            $room = $this->createClonedRoom($prototype, $repeat, $startTmp);
+            $room = $this->createClonedRoom($prototype, $repeat, $start);
             $repeat->addRoom($room);
             $this->em->persist($room);
-            $start->modify('+' . $repeat->getRepeaterWeeks() . ' weeks');
+            $start = $start->modify('+' . $repeat->getRepeaterWeeks() . ' weeks');
         }
         $this->em->persist($repeat);
         $this->em->flush();
@@ -174,14 +172,13 @@ class RepeaterService
 
         $start = $repeat->getStartDate();
         $prototype = $repeat->getPrototyp();
-        $start->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
+        $start = $start->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
 
         for ($i = 0; $i < $repeat->getRepetation(); $i++) {
-            $startTmp = clone $start;
-            $room = $this->createClonedRoom($prototype, $repeat, $startTmp);
+            $room = $this->createClonedRoom($prototype, $repeat, $start);
             $repeat->addRoom($room);
             $this->em->persist($room);
-            $start->modify('+' . $repeat->getRepeatMontly() . ' months');
+            $start = $start->modify('+' . $repeat->getRepeatMontly() . ' months');
         }
         $this->em->persist($repeat);
         $this->em->flush();
@@ -198,34 +195,31 @@ class RepeaterService
 
         $s = $repeat->getStartDate();
         $prototype = $repeat->getPrototyp();
-        $s->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
-        $start = clone $s;
-        $startTmp = clone $start;
-        $startTmp->modify('first day of this month');
+        $start = $s->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
+        $startTmp = $start->modify('first day of this month');
         $text = $this->number[$repeat->getRepatMonthRelativNumber()] . ' ' . $this->days[$repeat->getRepatMonthRelativWeekday()] . ' of this month';
-        $startTmp->modify($text);
-        $startTmp->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
+        $startTmp = $startTmp->modify($text);
+        $startTmp = $startTmp->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
         $sollCounter = $repeat->getRepetation();
         if ($startTmp >= $start) {
             $room = $this->createClonedRoom($prototype, $repeat, $startTmp);
             $repeat->addRoom($room);
             $this->em->persist($room);
-            $start->modify('first day of this month');
-            $start->modify('+' . ($repeat->getRepeatMonthlyRelativeHowOften()) . ' months');
+            $start = $start->modify('first day of this month');
+            $start = $start->modify('+' . ($repeat->getRepeatMonthlyRelativeHowOften()) . ' months');
             $sollCounter--;
         } else {
-            $start->modify('first day of next Month');
+            $start = $start->modify('first day of next Month');
         }
 
         for ($i = 0; $i < $sollCounter; $i++) {
-            $start->modify($text);
-            $startTmp = clone $start;
-            $startTmp->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
+            $start = $start->modify($text);
+            $startTmp = $start->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
             $room = $this->createClonedRoom($prototype, $repeat, $startTmp);
             $this->em->persist($room);
             $repeat->addRoom($room);
-            $start->modify('first day of this month');
-            $start->modify('+' . ($repeat->getRepeatMonthlyRelativeHowOften()) . ' months');
+            $start = $start->modify('first day of this month');
+            $start = $start->modify('+' . ($repeat->getRepeatMonthlyRelativeHowOften()) . ' months');
         }
 
         $this->em->persist($repeat);
@@ -242,14 +236,12 @@ class RepeaterService
     {
         $s = $repeat->getStartDate();
         $prototype = $repeat->getPrototyp();
-        $s->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
-        $start = clone $s;
+        $start = $s->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
         for ($i = 0; $i < $repeat->getRepetation(); $i++) {
-            $startTmp = clone $start;
-            $room = $this->createClonedRoom($prototype, $repeat, $startTmp);
+            $room = $this->createClonedRoom($prototype, $repeat, $start);
             $repeat->addRoom($room);
             $this->em->persist($room);
-            $start->modify('+' . $repeat->getRepeatYearly() . ' years');
+            $start = $start->modify('+' . $repeat->getRepeatYearly() . ' years');
         }
         $this->em->persist($repeat);
         $this->em->flush();
@@ -267,34 +259,31 @@ class RepeaterService
 
         $s = $repeat->getStartDate();
         $prototype = $repeat->getPrototyp();
-        $s->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
-        $start = clone $s;
-        $startTmp = clone $start;
-        $startTmp->modify('first day of this year');
+        $start = $s->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
+        $startTmp = $start->modify('first day of this year');
         $text = $this->number[$repeat->getRepeatYearlyRelativeNumber()] . ' ' . $this->days[$repeat->getRepeatYearlyRelativeWeekday()] . ' of ' . $this->months[$repeat->getRepeatYearlyRelativeMonth()];
-        $startTmp->modify($text);
+        $startTmp = $startTmp->modify($text);
         $sollCounter = $repeat->getRepetation();
-        $startTmp->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
+        $startTmp = $startTmp->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
         if ($startTmp >= $start) {
             $room = $this->createClonedRoom($prototype, $repeat, $startTmp);
             $repeat->addRoom($room);
             $this->em->persist($room);
             $sollCounter--;
-            $start->modify('first day of this month');
-            $start->modify('+' . ($repeat->getRepeatYearlyRelativeHowOften()) . ' years');
+            $start = $start->modify('first day of this month');
+            $start = $start->modify('+' . ($repeat->getRepeatYearlyRelativeHowOften()) . ' years');
         } else {
-            $start->modify('first day of next Year');
+            $start = $start->modify('first day of next Year');
         }
 
         for ($i = 0; $i < $sollCounter; $i++) {
-            $start->modify($text);
-            $startTmp = clone $start;
-            $startTmp->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
+            $start = $start->modify($text);
+            $startTmp = $start->setTime($prototype->getStart()->format('H'), $prototype->getStart()->format('i'));
             $room = $this->createClonedRoom($prototype, $repeat, $startTmp);
             $repeat->addRoom($room);
             $this->em->persist($room);
-            $start->modify('first day of this month');
-            $start->modify('+' . ($repeat->getRepeatYearlyRelativeHowOften()) . ' years');
+            $start = $start->modify('first day of this month');
+            $start = $start->modify('+' . ($repeat->getRepeatYearlyRelativeHowOften()) . ' years');
         }
         $this->em->persist($repeat);
         $this->em->flush();
@@ -305,11 +294,11 @@ class RepeaterService
      * This function clones the prototype and sets all paramters which are necesarry
      * @param Rooms $prototype
      * @param Repeat $repeat
-     * @param \DateTime $start
+     * @param \DateTimeImmutable $start
      * @return Rooms
      * @author Emanuel Holzmann
      */
-    function createClonedRoom(Rooms $prototype, Repeat $repeat, \DateTime $start): Rooms
+    function createClonedRoom(Rooms $prototype, Repeat $repeat, \DateTimeImmutable $start): Rooms
     {
 
         $room = clone $prototype;
@@ -325,8 +314,7 @@ class RepeaterService
         $room->setRepeaterRemoved(false);
         $room->setRepeater($repeat);
         $room->setStart($start);
-        $end = clone $start;
-        $end->modify('+' . $prototype->getDuration() . ' min');
+        $end = $start->modify('+' . $prototype->getDuration() . ' min');
         $room->setEnddate($end);
         return $room;
     }
@@ -363,7 +351,7 @@ class RepeaterService
     public function prepareRepeater(Rooms $rooms)
     {
 
-        $rooms->setEnddate((clone $rooms->getStart())->modify('+' . $rooms->getDuration() . 'min'));
+        $rooms->setEnddate($rooms->getStart()->modify('+' . $rooms->getDuration() . 'min'));
         $this->em->persist($rooms);
         $this->em->flush();
 

--- a/src/Service/RoomCheckService.php
+++ b/src/Service/RoomCheckService.php
@@ -31,9 +31,9 @@ class RoomCheckService
 
         $room = $this->setRoomProps($room);
         if ($room->getStart()) {
-            $now = (new \DateTime())->getTimestamp();
-            $start = (new \DateTime($room->getStart()->format('Y-m-d H:i:s'), $room->getTimeZone() ? new \DateTimeZone($room->getTimeZone()) : null))->getTimestamp();
-            $end = (new \DateTime((clone $room->getStart())->modify('+' . $room->getDuration() . 'min')->format('Y-m-d H:i:s'), $room->getTimeZone() ? new \DateTimeZone($room->getTimeZone()) : null))->getTimestamp();
+            $now = (new \DateTimeImmutable())->getTimestamp();
+            $start = (new \DateTimeImmutable($room->getStart()->format('Y-m-d H:i:s'), $room->getTimeZone() ? new \DateTimeZone($room->getTimeZone()) : null))->getTimestamp();
+            $end = (new \DateTimeImmutable($room->getStart()->modify('+' . $room->getDuration() . 'min')->format('Y-m-d H:i:s'), $room->getTimeZone() ? new \DateTimeZone($room->getTimeZone()) : null))->getTimestamp();
             if (($start < $now && $end < $now) && !$room->getPersistantRoom()) {
                 $error[] = $this->translator->trans('Fehler, das Startdatum und das Enddatum liegen in der Vergangenheit');
             }
@@ -64,7 +64,7 @@ class RoomCheckService
             $room->setEnddate(null);
         } else {
             if ($room->getStart()) {
-                $room->setEnddate((clone $room->getStart())->modify('+ ' . $room->getDuration() . ' minutes'));
+                $room->setEnddate($room->getStart()->modify('+ ' . $room->getDuration() . ' minutes'));
             }
         }
         return $room;

--- a/src/Service/RoomGeneratorService.php
+++ b/src/Service/RoomGeneratorService.php
@@ -84,7 +84,7 @@ class RoomGeneratorService
     {
         $roomCaller = new CallerRoom();
         $roomCaller->setCallerId($this->callerPrepareService->generateRoomId(999999));
-        $roomCaller->setCreatedAt(new \DateTime());
+        $roomCaller->setCreatedAt(new \DateTimeImmutable());
         $room->setCallerRoom($roomCaller);
         return $room;
     }

--- a/src/Service/SchedulingService.php
+++ b/src/Service/SchedulingService.php
@@ -34,8 +34,7 @@ class SchedulingService
         $room = $schedulingTime->getScheduling()->getRoom();
         $room->setScheduleMeeting(false);
         $room->setStart($schedulingTime->getTime());
-        $end = clone $schedulingTime->getTime();
-        $end->modify('+' . $room->getDuration() . 'min');
+        $end = $schedulingTime->getTime()->modify('+' . $room->getDuration() . 'min');
         $room->setEnddate($end);
         $this->em->persist($room);
         $this->em->flush();

--- a/src/Service/Star/StarService.php
+++ b/src/Service/Star/StarService.php
@@ -21,7 +21,7 @@ class StarService
     {
         try {
             $star = new Star();
-            $star->setCreatedAt(new \DateTime());
+            $star->setCreatedAt(new \DateTimeImmutable());
             if ($comment !== '') {
                 $star->setComment($comment);
             }

--- a/src/Service/StartMeetingService.php
+++ b/src/Service/StartMeetingService.php
@@ -223,7 +223,7 @@ class StartMeetingService
             $lobbyUser->setType($this->type);
             $lobbyUser->setUser($this->user);
             $lobbyUser->setRoom($this->room);
-            $lobbyUser->setCreatedAt(new \DateTime());
+            $lobbyUser->setCreatedAt(new \DateTimeImmutable());
             $lobbyUser->setUid(md5(uniqid()));
             $lobbyUser->setShowName($this->name);
             $this->em->persist($lobbyUser);
@@ -291,12 +291,12 @@ class StartMeetingService
     public static function checkTime(Rooms $room, ?User $user = null)
     {
 
-        $now = new \DateTime('now', new \DateTimeZone('utc'));
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('utc'));
         $start = null;
         $endDate = null;
         if (!$room->getPersistantRoom()) {
-            $start = (clone $room->getStartUtc())->modify('-30min');
-            $endDate = clone $room->getEndDateUtc();
+            $start = $room->getStartUtc()->modify('-30min');
+            $endDate = $room->getEndDateUtc();
         }
 
 

--- a/src/Service/SubcriptionService.php
+++ b/src/Service/SubcriptionService.php
@@ -174,7 +174,7 @@ class SubcriptionService
     function createNewWaitinglist(User $user, Rooms $rooms)
     {
         $waitingList = new Waitinglist();
-        $waitingList->setUser($user)->setRoom($rooms)->setCreatedAt(new \DateTime());
+        $waitingList->setUser($user)->setRoom($rooms)->setCreatedAt(new \DateTimeImmutable());
         $this->em->persist($waitingList);
         $this->em->flush();
         $res['text'] = $this->translator->trans('Vielen Dank für die Anmeldung. Bitte bestätigen Sie Ihre Emailadresse in der Email, die wir ihnen zugeschickt haben.');

--- a/src/Service/Theme/ThemeService.php
+++ b/src/Service/Theme/ThemeService.php
@@ -233,8 +233,8 @@ class ThemeService
     {
         $validUntil = $this->getThemeProperty('validUntil');
         if ($validUntil) {
-            $validDate = new \DateTime($validUntil);
-            $now = new \DateTime();
+            $validDate = new \DateTimeImmutable($validUntil);
+            $now = new \DateTimeImmutable();
             $daysDifff = intval(($now->diff($validDate))->format('%R%a'));
             if ($daysDifff < $this->getApplicationProperties('SECURITY_THEME_REMINDER_DAYS')) {
                 $this->request->getSession()->getBag('flashes')->add(

--- a/src/Service/UserCreatorService.php
+++ b/src/Service/UserCreatorService.php
@@ -31,7 +31,7 @@ class UserCreatorService
         $user = $this->em->getRepository(User::class)->findOneBy(['username' => $userName]);
         if (!$user) {
             $user = new User();
-            $user->setCreatedAt(new \DateTime())
+            $user->setCreatedAt(new \DateTimeImmutable())
                 ->setUsername($userName)
                 ->setLastName($lastName)
                 ->setFirstName($firstName)

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -124,7 +124,7 @@ class UserService
         } elseif ($room->getPersistantRoom()) {
             return $this->userRemoveService->removePersistantRoom($user, $room);
         } else {
-            if ($room->getEnddate() > new \DateTime()) {
+            if ($room->getEnddate() > new \DateTimeImmutable()) {
                 $this->userRemoveService->removeRoom($user, $room);
             }
         }

--- a/src/Service/Websocket/WebsocketJwtService.php
+++ b/src/Service/Websocket/WebsocketJwtService.php
@@ -23,9 +23,9 @@ class WebsocketJwtService
             'aud' => 'jitsi-admin',
             'sub' => $user ? $user->getUid() : null,
             'status' => $user ? $this->onlineStatusService->getUserStatus($user) : 0,
-            'iat' => (new \DateTime())->getTimestamp(),
-            'nbf' => (new \DateTime())->getTimestamp(),
-            'exp' => (new \DateTime())->modify('+3days')->getTimestamp(),
+            'iat' => (new \DateTimeImmutable())->getTimestamp(),
+            'nbf' => (new \DateTimeImmutable())->getTimestamp(),
+            'exp' => (new \DateTimeImmutable())->modify('+3days')->getTimestamp(),
             'rooms' => $rooms
         ];
 

--- a/src/Service/Whiteboard/WhiteboardJwtService.php
+++ b/src/Service/Whiteboard/WhiteboardJwtService.php
@@ -18,8 +18,8 @@ class WhiteboardJwtService
     {
         $ui = $this->uidHelper->getUid($rooms);
         $payload = [
-            'iat' => (new \DateTime())->getTimestamp(),
-            'exp' => (new \DateTime())->modify('+3days')->getTimestamp(),
+            'iat' => (new \DateTimeImmutable())->getTimestamp(),
+            'exp' => (new \DateTimeImmutable())->modify('+3days')->getTimestamp(),
             'roles' => [($isModerator ? 'moderator' : 'editor') . ':' . $ui]
         ];
         return JWT::encode($payload, $this->parameterBag->get('WHITEBOARD_SECRET'),'HS256');

--- a/src/Service/adhocmeeting/AdhocMeetingService.php
+++ b/src/Service/adhocmeeting/AdhocMeetingService.php
@@ -39,12 +39,12 @@ class AdhocMeetingService
         } else {
             $room->setTag(null);
         }
-        $now = new \DateTime('now', TimeZoneService::getTimeZone($creator));
+        $now = new \DateTimeImmutable('now', TimeZoneService::getTimeZone($creator));
         $room->setStart($now);
         if ($this->theme->getApplicationProperties('allowTimeZoneSwitch') == 1) {
             $room->setTimeZone($creator->getTimeZone());
         }
-        $room->setEnddate((clone $now)->modify('+ 1 hour'));
+        $room->setEnddate($now->modify('+ 1 hour'));
         $room->setDuration(60);
         $room->setName($this->translator->trans('Konferenz mit {n}', ['{n}' => $creator->getFormatedName($this->parameterBag->get('laf_showName'))]));
         $room->setSecondaryName($this->translator->trans('Konferenz mit {n}', ['{n}' => $reciever->getFormatedName($this->parameterBag->get('laf_showName'))]));

--- a/src/Service/api/RoomService.php
+++ b/src/Service/api/RoomService.php
@@ -36,7 +36,7 @@ class RoomService
         $this->userCreatorService = $userCreatorService;
     }
 
-    public function createRoom(User $user, Server $server, \DateTime $start, $duration, $name)
+    public function createRoom(User $user, Server $server, \DateTimeImmutable $start, $duration, $name)
     {
         // We initialize the Room with the data;
 
@@ -49,7 +49,7 @@ class RoomService
         $room->setSequence(0);
         $room->setUidReal(md5(uniqid('h2-invent', true)));
         $room->setStart($start);
-        $room->setEnddate((clone $room->getStart())->modify('+ ' . $room->getDuration() . ' minutes'));
+        $room->setEnddate($room->getStart()->modify('+ ' . $room->getDuration() . ' minutes'));
         $room->setServer($server);
         $room = $this->roomGeneratorService->createCallerId($room);
         $this->em->persist($room);
@@ -59,7 +59,7 @@ class RoomService
         return $room;
     }
 
-    public function editRoom(Rooms $room, Server $server, \DateTime $start, $duration, $name)
+    public function editRoom(Rooms $room, Server $server, \DateTimeImmutable $start, $duration, $name)
     {
         // We initialize the Room with the data;
 
@@ -68,7 +68,7 @@ class RoomService
         $room->setDuration($duration);
         $room->setSequence(0);
         $room->setStart($start);
-        $room->setEnddate((clone $room->getStart())->modify('+ ' . $room->getDuration() . ' minutes'));
+        $room->setEnddate($room->getStart()->modify('+ ' . $room->getDuration() . ' minutes'));
         $room->setServer($server);
 
         $this->em->persist($room);

--- a/src/Service/caller/CallerFindRoomService.php
+++ b/src/Service/caller/CallerFindRoomService.php
@@ -19,7 +19,7 @@ class CallerFindRoomService
     public function findRoom($id)
     {
         $caller = $this->em->getRepository(CallerRoom::class)->findOneBy(['callerId' => $id]);
-        $now = (new \DateTime())->getTimestamp();
+        $now = (new \DateTimeImmutable())->getTimestamp();
         if (!$caller) {
             return ['status' => 'ROOM_ID_UKNOWN', 'reason' => 'ROOM_ID_UKNOWN', 'links' => []];
         }

--- a/src/Service/caller/CallerPinService.php
+++ b/src/Service/caller/CallerPinService.php
@@ -55,7 +55,7 @@ class CallerPinService
         $this->loggger->debug('We create a session for the caller', ['roomId' => $roomId, 'callerId' => $callerId, 'pin' => $pin]);
         $session = new CallerSession();
         $session->setSessionId(md5($roomId . $pin . uniqid()))
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setAuthOk(false)
             ->setLobbyWaitingUser($lobbyUser)
             ->setCallerId($callerId)

--- a/src/Service/caller/CallerPrepareService.php
+++ b/src/Service/caller/CallerPrepareService.php
@@ -42,7 +42,7 @@ class CallerPrepareService
      */
     public function deleteOldId()
     {
-        $now = (new \DateTime())->getTimestamp();
+        $now = (new \DateTimeImmutable())->getTimestamp();
         $oldCallerId = $this->em->getRepository(CallerRoom::class)->findPastRoomsWithCallerId($now);
         foreach ($oldCallerId as $data) {
             $this->em->remove($data);
@@ -57,7 +57,7 @@ class CallerPrepareService
      */
     public function addNewId()
     {
-        $now = (new \DateTime())->getTimestamp();
+        $now = (new \DateTimeImmutable())->getTimestamp();
         $futureRooms = $this->em->getRepository(Rooms::class)->findFutureRoomsWithNoCallerId($now);
         foreach ($futureRooms as $data) {
             $this->addCallerIdToRoom($data);
@@ -77,7 +77,7 @@ class CallerPrepareService
         if (!$callerId) {
             $callerId = new CallerRoom();
             $callerId->setRoom($rooms);
-            $callerId->setCreatedAt(new \DateTime());
+            $callerId->setCreatedAt(new \DateTimeImmutable());
             $callerId->setCallerId($this->generateRoomId(999999));
             $this->em->persist($callerId);
             $this->em->flush();
@@ -144,7 +144,7 @@ class CallerPrepareService
                 $callerID
                     ->setRoom($rooms)
                     ->setUser($data)
-                    ->setCreatedAt(new \DateTime())
+                    ->setCreatedAt(new \DateTimeImmutable())
                     ->setCallerId($this->generateCallerUserId($rooms, 999999));
                 $rooms->addCallerId($callerID);
             }
@@ -166,7 +166,7 @@ class CallerPrepareService
             $callerID
                 ->setRoom($prototype)
                 ->setUser($pUser)
-                ->setCreatedAt(new \DateTime())
+                ->setCreatedAt(new \DateTimeImmutable())
                 ->setCallerId($this->generateCallerUserId($prototype, 999999));
             foreach ($repeat->getRooms() as $room){
                 $callerIDClone = clone $callerID;

--- a/src/Service/ldap/LdapService.php
+++ b/src/Service/ldap/LdapService.php
@@ -248,7 +248,7 @@ class LdapService
                             $deputy = $this->em->getRepository(Deputy::class)->findOneBy(['manager' => $l, 'deputy' => $mem->getUser()]);
                             if (!$deputy) {
                                 $deputy = new Deputy();
-                                $deputy->setCreatedAt(new \DateTime())
+                                $deputy->setCreatedAt(new \DateTimeImmutable())
                                     ->setDeputy($mem->getUser())
                                     ->setManager($l);
                             }

--- a/src/Service/livekit/SipTrunkGenerator.php
+++ b/src/Service/livekit/SipTrunkGenerator.php
@@ -72,7 +72,7 @@ class SipTrunkGenerator
     {
         $this->rooms = $rooms;
         $this->server = $server;
-        $this->sipTrunkNumber = (new \DateTime())->format('U').rand(10, 99);
+        $this->sipTrunkNumber = (new \DateTimeImmutable())->format('U').rand(10, 99);
         $payload = [
             'trunk' => [
                 'name' => $this->livekitRoomNameGenerator->getLiveKitName($rooms),

--- a/src/Service/webhook/RoomWebhookService.php
+++ b/src/Service/webhook/RoomWebhookService.php
@@ -122,7 +122,7 @@ class RoomWebhookService
 
             if ($roomStatus) {
                 $roomStatus->setJitsiRoomId($roomJid);
-                $roomStatus->setUpdatedAt(new \DateTime());
+                $roomStatus->setUpdatedAt(new \DateTimeImmutable());
                 $this->em->persist($roomStatus);
                 $this->em->flush();
                 $text = 'Room already created';
@@ -131,12 +131,12 @@ class RoomWebhookService
             }
 
                 $roomStatus = new RoomStatus();
-                $roomStatus->setCreatedAt(new \DateTime())
+                $roomStatus->setCreatedAt(new \DateTimeImmutable())
                     ->setJitsiRoomId($roomJid)
                     ->setRoom($room);
 
-            $roomStatus->setRoomCreatedAt(\DateTime::createFromFormat('U', $createdAt))
-                ->setUpdatedAt(new \DateTime())
+            $roomStatus->setRoomCreatedAt(\DateTimeImmutable::createFromFormat('U', $createdAt))
+                ->setUpdatedAt(new \DateTimeImmutable())
                 ->setCreated(true);
 
             $this->em->persist($roomStatus);
@@ -184,8 +184,8 @@ class RoomWebhookService
                 return null;
             }
 
-            $roomStatus->setDestroyedAt(\DateTime::createFromFormat('U', $destroyedAt))
-                ->setUpdatedAt(new \DateTime())
+            $roomStatus->setDestroyedAt(\DateTimeImmutable::createFromFormat('U', $destroyedAt))
+                ->setUpdatedAt(new \DateTimeImmutable())
                 ->setDestroyed(true);
 
             $this->em->persist($roomStatus);
@@ -197,7 +197,7 @@ class RoomWebhookService
 
             foreach ($roomStatus->getRoomStatusParticipants() as $data2) {
                 if($data2->getInRoom()){
-                    $data2->setLeftRoomAt(\DateTime::createFromFormat('U', $destroyedAt))
+                    $data2->setLeftRoomAt(\DateTimeImmutable::createFromFormat('U', $destroyedAt))
                         ->setInRoom(false);
                     $this->em->persist($data2);
                 }
@@ -254,7 +254,7 @@ class RoomWebhookService
                 return 'NO_DATA';
             }
             $roomPart = new RoomStatusParticipant();
-            $roomPart->setEnteredRoomAt(\DateTime::createFromFormat('U', $joinedAt))
+            $roomPart->setEnteredRoomAt(\DateTimeImmutable::createFromFormat('U', $joinedAt))
                 ->setInRoom(true)
                 ->setParticipantId($occupantJId)
                 ->setParticipantName($occupantName ?? 'No Data')
@@ -300,7 +300,7 @@ class RoomWebhookService
                 return $text;
             }
 
-            $roomPart->setLeftRoomAt(\DateTime::createFromFormat('U', $leftAt))
+            $roomPart->setLeftRoomAt(\DateTimeImmutable::createFromFormat('U', $leftAt))
                 ->setInRoom(false)
                 ->setDominantSpeakerTime($totalDominantSpeakerTime);
 

--- a/src/Twig/License.php
+++ b/src/Twig/License.php
@@ -36,7 +36,7 @@ class License extends AbstractExtension
         return $this->licenseService->verify($server);
     }
 
-    public function validateUntilLicense(Server $server): \DateTime
+    public function validateUntilLicense(Server $server): \DateTimeImmutable
     {
         return $this->licenseService->validUntil($server);
     }

--- a/src/Twig/RoomsInFuture.php
+++ b/src/Twig/RoomsInFuture.php
@@ -37,7 +37,7 @@ class RoomsInFuture extends AbstractExtension
 
     public function roomsinFuture(Server $server)
     {
-        $now = new \DateTime('now', new \DateTimeZone('utc'));
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('utc'));
         $qb = $this->em->getRepository(Rooms::class)->createQueryBuilder('rooms');
         $qb->andWhere('rooms.server = :server')
             ->andWhere('rooms.showRoomOnJoinpage = true')

--- a/src/Twig/Time.php
+++ b/src/Twig/Time.php
@@ -30,7 +30,7 @@ class Time extends AbstractExtension
 
     public function getTime(User $user)
     {
-        $now = new \DateTime('now', new \DateTimeZone($user->getTimeZone()));
+        $now = new \DateTimeImmutable('now', new \DateTimeZone($user->getTimeZone()));
         return $now;
     }
 }

--- a/tests/API/ApiTest.php
+++ b/tests/API/ApiTest.php
@@ -24,7 +24,7 @@ class ApiTest extends WebTestCase
                 'name' => 'TestApi',
                 'duration' => 70,
                 'server' => 'meet.jit.si2',
-                'start' => (new \DateTime())->format('Y-m-d') . 'T' . (new \DateTime())->format('H:i'),
+                'start' => (new \DateTimeImmutable())->format('Y-m-d') . 'T' . (new \DateTimeImmutable())->format('H:i'),
                 'keycloakId' => '123456'
             ]
         );
@@ -46,7 +46,7 @@ class ApiTest extends WebTestCase
                 'email' => 'test@local.de',
                 'duration' => 70,
                 'server' => 'meet.jit.si2',
-                'start' => (new \DateTime())->format('Y-m-d') . 'T' . (new \DateTime())->format('H:i'),
+                'start' => (new \DateTimeImmutable())->format('Y-m-d') . 'T' . (new \DateTimeImmutable())->format('H:i'),
                 'keycloakId' => '123456'
             ]
         );
@@ -69,7 +69,7 @@ class ApiTest extends WebTestCase
                 'name' => 'TestApi',
                 'duration' => 70,
                 'server' => 'meet.jit.si2',
-                'start' => (new \DateTime())->format('Y-m-d') . 'T' . (new \DateTime())->format('H:i'),
+                'start' => (new \DateTimeImmutable())->format('Y-m-d') . 'T' . (new \DateTimeImmutable())->format('H:i'),
                 'keycloakId' => '123456'
             ]
         );

--- a/tests/ConferenceMapper/ConferenceMapperControllerCallerIdTest.php
+++ b/tests/ConferenceMapper/ConferenceMapperControllerCallerIdTest.php
@@ -27,11 +27,11 @@ class ConferenceMapperControllerCallerIdTest extends WebTestCase
         $manager = self::getContainer()->get(EntityManagerInterface::class);
         $status = new RoomStatus();
         $status->setRoom($callerRoom->getRoom())
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $callerRoom->getRoom()->getServer()->setJigasiProsodyDomain('testdomain.com');
         $manager->flush();
@@ -69,11 +69,11 @@ class ConferenceMapperControllerCallerIdTest extends WebTestCase
         $manager = self::getContainer()->get(EntityManagerInterface::class);
         $status = new RoomStatus();
         $status->setRoom($callerRoom->getRoom())
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $callerRoom->getRoom()->getServer()->setJigasiProsodyDomain('testdomain.com');
         $manager->flush();

--- a/tests/ConferenceMapper/ConferenceMapperControllerTest.php
+++ b/tests/ConferenceMapper/ConferenceMapperControllerTest.php
@@ -63,11 +63,11 @@ class ConferenceMapperControllerTest extends WebTestCase
         $manager = self::getContainer()->get(EntityManagerInterface::class);
         $status = new RoomStatus();
         $status->setRoom($callerRoom->getRoom())
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $callerRoom->getRoom()->getServer()->setJigasiProsodyDomain('testdomain.com');
         $manager->flush();

--- a/tests/ConferenceMapper/ConferenceMapperTest.php
+++ b/tests/ConferenceMapper/ConferenceMapperTest.php
@@ -88,11 +88,11 @@ class ConferenceMapperTest extends KernelTestCase
         $manager = self::getContainer()->get(EntityManagerInterface::class);
         $status = new RoomStatus();
         $status->setRoom($callerRoom->getRoom())
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $manager->flush();
         $callerRoom->getRoom()->addRoomstatus($status);

--- a/tests/ConferenceMapper/EventSyncRelaisControllerTest.php
+++ b/tests/ConferenceMapper/EventSyncRelaisControllerTest.php
@@ -37,7 +37,7 @@ class EventSyncRelaisControllerTest extends WebTestCase
         $callerRoom = new CallerRoom();
         $callerRoom->setRoom($room)
             ->setCallerId('555555')
-            ->setCreatedAt(new \DateTime());
+            ->setCreatedAt(new \DateTimeImmutable());
         $room->setUid('testUID1234');
         $room->getServer()->setJitsiEventSyncUrl('http://example.com')->setJigasiProsodyDomain('test.prosody.com');
         $manager->persist($room);
@@ -77,7 +77,7 @@ class EventSyncRelaisControllerTest extends WebTestCase
         $callerRoom = new CallerRoom();
         $callerRoom->setRoom($room)
             ->setCallerId('555555')
-            ->setCreatedAt(new \DateTime());
+            ->setCreatedAt(new \DateTimeImmutable());
         $room->getServer()->setJitsiEventSyncUrl('http://example.com');
         $manager->persist($room);
         $manager->persist($callerRoom);

--- a/tests/Dashboard/RoomStatusFrontendServiceTest.php
+++ b/tests/Dashboard/RoomStatusFrontendServiceTest.php
@@ -146,13 +146,13 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
 
         $roomStatus = new RoomStatus();
         $roomStatus->setCreated(true)
-            ->setRoomCreatedAt((new \DateTime())->modify('-3 hours'))
+            ->setRoomCreatedAt((new \DateTimeImmutable())->modify('-3 hours'))
             ->setRoom($room)
             ->setJitsiRoomId('testclosed@test.de')
             ->setDestroyed(true)
-            ->setDestroyedAt((new \DateTime())->modify('-1 hour'))
-            ->setUpdatedAt(new \DateTime())
-            ->setCreatedAt(new \DateTime());
+            ->setDestroyedAt((new \DateTimeImmutable())->modify('-1 hour'))
+            ->setUpdatedAt(new \DateTimeImmutable())
+            ->setCreatedAt(new \DateTimeImmutable());
         $em->persist($roomStatus);
         $em->flush();
 
@@ -238,23 +238,23 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
 
         $roomStatus1 = new RoomStatus();
         $roomStatus1->setCreated(true)
-            ->setRoomCreatedAt((new \DateTime())->modify('-3 hours'))
+            ->setRoomCreatedAt((new \DateTimeImmutable())->modify('-3 hours'))
             ->setRoom($room)
             ->setJitsiRoomId('partial1@test.de')
             ->setDestroyed(true)
-            ->setDestroyedAt((new \DateTime())->modify('-2 hours'))
-            ->setUpdatedAt(new \DateTime())
-            ->setCreatedAt(new \DateTime());
+            ->setDestroyedAt((new \DateTimeImmutable())->modify('-2 hours'))
+            ->setUpdatedAt(new \DateTimeImmutable())
+            ->setCreatedAt(new \DateTimeImmutable());
         $em->persist($roomStatus1);
 
         $roomStatus2 = new RoomStatus();
         $roomStatus2->setCreated(true)
-            ->setRoomCreatedAt((new \DateTime())->modify('-1 hour'))
+            ->setRoomCreatedAt((new \DateTimeImmutable())->modify('-1 hour'))
             ->setRoom($room)
             ->setJitsiRoomId('partial2@test.de')
             ->setDestroyed(null)
-            ->setUpdatedAt(new \DateTime())
-            ->setCreatedAt(new \DateTime());
+            ->setUpdatedAt(new \DateTimeImmutable())
+            ->setCreatedAt(new \DateTimeImmutable());
         $em->persist($roomStatus2);
         $em->flush();
 
@@ -291,7 +291,7 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
         $this->assertArrayNotHasKey($yesterdayRoom->getId(), $closedMap);
     }
 
-    private function createRoom(EntityManagerInterface $em, string $name, ?\DateTimeInterface $start = null): Rooms
+    private function createRoom(EntityManagerInterface $em, string $name, ?\DateTimeImmutable $start = null): Rooms
     {
         $roomRepo = $this->getContainer()->get(RoomsRepository::class);
         $room = $roomRepo->findOneBy(['name' => $name]);
@@ -319,7 +319,7 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
         return $room;
     }
 
-    private function createStatus(EntityManagerInterface $em, Rooms $room, string $jitsiId, ?bool $destroyed, ?\DateTimeInterface $destroyedAt = null, ?\DateTimeInterface $roomCreatedAt = null): RoomStatus
+    private function createStatus(EntityManagerInterface $em, Rooms $room, string $jitsiId, ?bool $destroyed, ?\DateTimeImmutable $destroyedAt = null, ?\DateTimeImmutable $roomCreatedAt = null): RoomStatus
     {
         $status = new RoomStatus();
         $status->setCreated(true)
@@ -327,9 +327,9 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
             ->setJitsiRoomId($jitsiId)
             ->setDestroyed($destroyed)
             ->setDestroyedAt($destroyedAt)
-            ->setRoomCreatedAt($roomCreatedAt ?? new \DateTime())
-            ->setUpdatedAt(new \DateTime())
-            ->setCreatedAt(new \DateTime());
+            ->setRoomCreatedAt($roomCreatedAt ?? new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable())
+            ->setCreatedAt(new \DateTimeImmutable());
         $em->persist($status);
         return $status;
     }
@@ -341,7 +341,7 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
 
         $em = $this->getContainer()->get(EntityManagerInterface::class);
         $service = $this->getContainer()->get(RoomStatusFrontendService::class);
-        $room = $this->createRoom($em, 'ClosedMapActiveRoom', new \DateTime('-2 hours'));
+        $room = $this->createRoom($em, 'ClosedMapActiveRoom', new \DateTimeImmutable('-2 hours'));
 
         $this->createStatus($em, $room, 'active-only@test.de', null);
         $em->flush();
@@ -359,9 +359,9 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
 
         $em = $this->getContainer()->get(EntityManagerInterface::class);
         $service = $this->getContainer()->get(RoomStatusFrontendService::class);
-        $room = $this->createRoom($em, 'ClosedMapDestroyedAfter', new \DateTime('-3 hours'));
+        $room = $this->createRoom($em, 'ClosedMapDestroyedAfter', new \DateTimeImmutable('-3 hours'));
 
-        $this->createStatus($em, $room, 'destroyed-after@test.de', true, new \DateTime('-1 hour'), new \DateTime('-3 hours'));
+        $this->createStatus($em, $room, 'destroyed-after@test.de', true, new \DateTimeImmutable('-1 hour'), new \DateTimeImmutable('-3 hours'));
         $em->flush();
 
         $result = $service->getRoomClosedStatusMap([$room->getId()]);
@@ -377,9 +377,9 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
 
         $em = $this->getContainer()->get(EntityManagerInterface::class);
         $service = $this->getContainer()->get(RoomStatusFrontendService::class);
-        $room = $this->createRoom($em, 'ClosedMapDestroyedBefore', new \DateTime('+2 hours'));
+        $room = $this->createRoom($em, 'ClosedMapDestroyedBefore', new \DateTimeImmutable('+2 hours'));
 
-        $this->createStatus($em, $room, 'destroyed-before@test.de', true, new \DateTime('-1 hour'), new \DateTime('-1 hour'));
+        $this->createStatus($em, $room, 'destroyed-before@test.de', true, new \DateTimeImmutable('-1 hour'), new \DateTimeImmutable('-1 hour'));
         $em->flush();
 
         $result = $service->getRoomClosedStatusMap([$room->getId()]);
@@ -395,7 +395,7 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
 
         $em = $this->getContainer()->get(EntityManagerInterface::class);
         $service = $this->getContainer()->get(RoomStatusFrontendService::class);
-        $room = $this->createRoom($em, 'ClosedMapNoStatus', new \DateTime('-2 hours'));
+        $room = $this->createRoom($em, 'ClosedMapNoStatus', new \DateTimeImmutable('-2 hours'));
 
         $result = $service->getRoomClosedStatusMap([$room->getId()]);
 
@@ -409,10 +409,10 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
 
         $em = $this->getContainer()->get(EntityManagerInterface::class);
         $service = $this->getContainer()->get(RoomStatusFrontendService::class);
-        $room = $this->createRoom($em, 'ClosedMapMixed', new \DateTime('-4 hours'));
+        $room = $this->createRoom($em, 'ClosedMapMixed', new \DateTimeImmutable('-4 hours'));
 
-        $this->createStatus($em, $room, 'mixed-1@test.de', true, new \DateTime('-2 hours'), new \DateTime('-4 hours'));
-        $this->createStatus($em, $room, 'mixed-2@test.de', null, null, new \DateTime('-1 hour'));
+        $this->createStatus($em, $room, 'mixed-1@test.de', true, new \DateTimeImmutable('-2 hours'), new \DateTimeImmutable('-4 hours'));
+        $this->createStatus($em, $room, 'mixed-2@test.de', null, null, new \DateTimeImmutable('-1 hour'));
         $em->flush();
 
         $result = $service->getRoomClosedStatusMap([$room->getId()]);
@@ -428,10 +428,10 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
 
         $em = $this->getContainer()->get(EntityManagerInterface::class);
         $service = $this->getContainer()->get(RoomStatusFrontendService::class);
-        $room = $this->createRoom($em, 'ClosedMapMultipleDestroyed', new \DateTime('-6 hours'));
+        $room = $this->createRoom($em, 'ClosedMapMultipleDestroyed', new \DateTimeImmutable('-6 hours'));
 
-        $this->createStatus($em, $room, 'multi-1@test.de', true, new \DateTime('-5 hours'), new \DateTime('-6 hours'));
-        $this->createStatus($em, $room, 'multi-2@test.de', true, new \DateTime('-1 hour'), new \DateTime('-2 hours'));
+        $this->createStatus($em, $room, 'multi-1@test.de', true, new \DateTimeImmutable('-5 hours'), new \DateTimeImmutable('-6 hours'));
+        $this->createStatus($em, $room, 'multi-2@test.de', true, new \DateTimeImmutable('-1 hour'), new \DateTimeImmutable('-2 hours'));
         $em->flush();
 
         $result = $service->getRoomClosedStatusMap([$room->getId()]);
@@ -447,9 +447,9 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
 
         $em = $this->getContainer()->get(EntityManagerInterface::class);
         $service = $this->getContainer()->get(RoomStatusFrontendService::class);
-        $room = $this->createRoom($em, 'ClosedMapDestroyedAtNull', new \DateTime('-2 hours'));
+        $room = $this->createRoom($em, 'ClosedMapDestroyedAtNull', new \DateTimeImmutable('-2 hours'));
 
-        $this->createStatus($em, $room, 'nn-destroyed@test.de', true, null, new \DateTime('-2 hours'));
+        $this->createStatus($em, $room, 'nn-destroyed@test.de', true, null, new \DateTimeImmutable('-2 hours'));
         $em->flush();
 
         $result = $service->getRoomClosedStatusMap([$room->getId()]);
@@ -465,15 +465,15 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
         $em = $this->getContainer()->get(EntityManagerInterface::class);
         $service = $this->getContainer()->get(RoomStatusFrontendService::class);
 
-        $activeRoom = $this->createRoom($em, 'BatchActiveRoom', new \DateTime('-1 hour'));
+        $activeRoom = $this->createRoom($em, 'BatchActiveRoom', new \DateTimeImmutable('-1 hour'));
         $this->createStatus($em, $activeRoom, 'batch-active@test.de', null);
         $em->flush();
 
-        $closedRoom = $this->createRoom($em, 'BatchClosedRoom', new \DateTime('-3 hours'));
-        $this->createStatus($em, $closedRoom, 'batch-closed@test.de', true, new \DateTime('-1 hour'), new \DateTime('-3 hours'));
+        $closedRoom = $this->createRoom($em, 'BatchClosedRoom', new \DateTimeImmutable('-3 hours'));
+        $this->createStatus($em, $closedRoom, 'batch-closed@test.de', true, new \DateTimeImmutable('-1 hour'), new \DateTimeImmutable('-3 hours'));
         $em->flush();
 
-        $emptyRoom = $this->createRoom($em, 'BatchEmptyRoom', new \DateTime('-2 hours'));
+        $emptyRoom = $this->createRoom($em, 'BatchEmptyRoom', new \DateTimeImmutable('-2 hours'));
 
         $result = $service->getRoomClosedStatusMap([$activeRoom->getId(), $closedRoom->getId(), $emptyRoom->getId()]);
 
@@ -491,10 +491,10 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
 
         $em = $this->getContainer()->get(EntityManagerInterface::class);
         $service = $this->getContainer()->get(RoomStatusFrontendService::class);
-        $room = $this->createRoom($em, 'ClosedMapNullDestroyed', new \DateTime('-2 hours'));
+        $room = $this->createRoom($em, 'ClosedMapNullDestroyed', new \DateTimeImmutable('-2 hours'));
 
         // destroyed explicitly NULL (not true) => still active
-        $this->createStatus($em, $room, 'null-destroyed@test.de', null, null, new \DateTime('-2 hours'));
+        $this->createStatus($em, $room, 'null-destroyed@test.de', null, null, new \DateTimeImmutable('-2 hours'));
         $em->flush();
 
         $result = $service->getRoomClosedStatusMap([$room->getId()]);
@@ -510,7 +510,7 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
 
         $em = $this->getContainer()->get(EntityManagerInterface::class);
         $service = $this->getContainer()->get(RoomStatusFrontendService::class);
-        $room = $this->createRoom($em, 'HasStatusActiveRoom', new \DateTime('-1 hour'));
+        $room = $this->createRoom($em, 'HasStatusActiveRoom', new \DateTimeImmutable('-1 hour'));
 
         $this->createStatus($em, $room, 'has-active@test.de', null);
         $em->flush();
@@ -528,9 +528,9 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
 
         $em = $this->getContainer()->get(EntityManagerInterface::class);
         $service = $this->getContainer()->get(RoomStatusFrontendService::class);
-        $room = $this->createRoom($em, 'HasStatusDestroyedRoom', new \DateTime('-3 hours'));
+        $room = $this->createRoom($em, 'HasStatusDestroyedRoom', new \DateTimeImmutable('-3 hours'));
 
-        $this->createStatus($em, $room, 'has-destroyed@test.de', true, new \DateTime('-1 hour'), new \DateTime('-3 hours'));
+        $this->createStatus($em, $room, 'has-destroyed@test.de', true, new \DateTimeImmutable('-1 hour'), new \DateTimeImmutable('-3 hours'));
         $em->flush();
 
         $result = $service->getRoomHasStatusMap([$room->getId()]);
@@ -546,7 +546,7 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
 
         $em = $this->getContainer()->get(EntityManagerInterface::class);
         $service = $this->getContainer()->get(RoomStatusFrontendService::class);
-        $room = $this->createRoom($em, 'HasStatusEmptyRoom', new \DateTime('-2 hours'));
+        $room = $this->createRoom($em, 'HasStatusEmptyRoom', new \DateTimeImmutable('-2 hours'));
 
         $result = $service->getRoomHasStatusMap([$room->getId()]);
 
@@ -585,15 +585,15 @@ class RoomStatusFrontendServiceTest extends KernelTestCase
         $em = $this->getContainer()->get(EntityManagerInterface::class);
         $service = $this->getContainer()->get(RoomStatusFrontendService::class);
 
-        $activeRoom = $this->createRoom($em, 'HasStatusBatchActive', new \DateTime('-1 hour'));
+        $activeRoom = $this->createRoom($em, 'HasStatusBatchActive', new \DateTimeImmutable('-1 hour'));
         $this->createStatus($em, $activeRoom, 'has-batch-active@test.de', null);
         $em->flush();
 
-        $destroyedRoom = $this->createRoom($em, 'HasStatusBatchDestroyed', new \DateTime('-3 hours'));
-        $this->createStatus($em, $destroyedRoom, 'has-batch-destroyed@test.de', true, new \DateTime('-1 hour'), new \DateTime('-3 hours'));
+        $destroyedRoom = $this->createRoom($em, 'HasStatusBatchDestroyed', new \DateTimeImmutable('-3 hours'));
+        $this->createStatus($em, $destroyedRoom, 'has-batch-destroyed@test.de', true, new \DateTimeImmutable('-1 hour'), new \DateTimeImmutable('-3 hours'));
         $em->flush();
 
-        $emptyRoom = $this->createRoom($em, 'HasStatusBatchEmpty', new \DateTime('-2 hours'));
+        $emptyRoom = $this->createRoom($em, 'HasStatusBatchEmpty', new \DateTimeImmutable('-2 hours'));
 
         $result = $service->getRoomHasStatusMap([$activeRoom->getId(), $destroyedRoom->getId(), $emptyRoom->getId()]);
 

--- a/tests/Dashboard/RoomsRepositoryDashboardTest.php
+++ b/tests/Dashboard/RoomsRepositoryDashboardTest.php
@@ -105,7 +105,7 @@ class RoomsRepositoryDashboardTest extends KernelTestCase
         $rooms = $roomRepo->findRoomsInPast($user, 0);
 
         $this->assertIsArray($rooms);
-        $now = new \DateTime('now', new \DateTimeZone('utc'));
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('utc'));
         foreach ($rooms as $room) {
             $this->assertNotNull($room->getEndDateUtc());
             $this->assertLessThan($now->getTimestamp(), $room->getEndDateUtc()->getTimestamp());

--- a/tests/Deputy/Controller/DeputyCreatorControllerTest.php
+++ b/tests/Deputy/Controller/DeputyCreatorControllerTest.php
@@ -56,7 +56,7 @@ class DeputyCreatorControllerTest extends WebTestCase
         $form['room[server]'] = $server->getId();
         $form['room[moderator]'] = $this->manager->getId();
         $form['room[name]'] = 'test for the supervisor';
-        $form['room[start]'] = (new \DateTime())->format('Y-m-d H:i:s');
+        $form['room[start]'] = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
         $form['room[duration]'] = "60";
 
         $this->client->submit($form);
@@ -131,7 +131,7 @@ class DeputyCreatorControllerTest extends WebTestCase
         $form['room[server]'] = $server->getId();
         $form['room[moderator]'] = $this->manager->getId();
         $form['room[name]'] = 'test for the supervisor';
-        $form['room[start]'] = (new \DateTime())->format('Y-m-d H:i:s');
+        $form['room[start]'] = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
         $form['room[duration]'] = "60";
 
         $this->client->submit($form);
@@ -158,7 +158,7 @@ class DeputyCreatorControllerTest extends WebTestCase
         $buttonCrawlerNode = $crawler->selectButton('Speichern');
         $form = $buttonCrawlerNode->form();
         $form['room[name]'] = 'test for the supervisor';
-        $form['room[start]'] = (new \DateTime())->format('Y-m-d H:i:s');
+        $form['room[start]'] = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
         $form['room[duration]'] = "60";
 
 

--- a/tests/Deputy/Controller/DeputyDashboardTest.php
+++ b/tests/Deputy/Controller/DeputyDashboardTest.php
@@ -27,7 +27,7 @@ class DeputyDashboardTest extends WebTestCase
         $form = $buttonCrawlerNode->form();
         $form['room[server]'] = $server->getId();
         $form['room[name]'] = 'test von deputy';
-        $form['room[start]'] = (new \DateTime())->format('Y-m-d') . 'T' . (new \DateTime())->format('H:i');
+        $form['room[start]'] = (new \DateTimeImmutable())->format('Y-m-d') . 'T' . (new \DateTimeImmutable())->format('H:i');
         $form['room[duration]'] = "60";
         $client->submit($form);
 
@@ -44,7 +44,7 @@ class DeputyDashboardTest extends WebTestCase
         $deputyEle = new Deputy();
         $deputyEle->setDeputy($deputy)
             ->setManager($master)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setIsFromLdap(false);
         $master->addManagerElement($deputyEle);
         $deputy->addDeputiesElement($deputyEle);
@@ -94,7 +94,7 @@ class DeputyDashboardTest extends WebTestCase
         $form['room[server]'] = $server->getId();
         $form['room[moderator]'] = $master->getId();
         $form['room[name]'] = 'test von deputy';
-        $form['room[start]'] = (new \DateTime())->format('Y-m-d') . 'T' . (new \DateTime())->format('H:i');
+        $form['room[start]'] = (new \DateTimeImmutable())->format('Y-m-d') . 'T' . (new \DateTimeImmutable())->format('H:i');
         $form['room[duration]'] = "60";
         $client->submit($form);
 

--- a/tests/Deputy/Controller/DeputyRoomOptionsControllerTest.php
+++ b/tests/Deputy/Controller/DeputyRoomOptionsControllerTest.php
@@ -43,7 +43,7 @@ class DeputyRoomOptionsControllerTest extends WebTestCase
         $form['room[server]'] = $server->getId();
         $form['room[moderator]'] = $manager->getId();
         $form['room[name]'] = 'test for the supervisor';
-        $form['room[start]'] = (new \DateTime())->format('Y-m-d H:i:s');
+        $form['room[start]'] = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
         $form['room[duration]'] = "60";
         $this->client->submit($form);
     }

--- a/tests/Deputy/DeputyRepositoryTest.php
+++ b/tests/Deputy/DeputyRepositoryTest.php
@@ -44,13 +44,13 @@ class DeputyRepositoryTest extends KernelTestCase
         $deputy1 = new Deputy();
         $deputy1->setManager($manager)
             ->setDeputy($deputyUser1)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setIsFromLdap(false);
 
         $deputy2 = new Deputy();
         $deputy2->setManager($manager)
             ->setDeputy($deputyUser2)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setIsFromLdap(true);
 
         $em->persist($deputy1);

--- a/tests/ExternalApplication/ApplicationUrlGeneratorTest.php
+++ b/tests/ExternalApplication/ApplicationUrlGeneratorTest.php
@@ -62,7 +62,7 @@ class ApplicationUrlGeneratorTest extends KernelTestCase
             ->setDays(2)
             ->setRepetation(10)
             ->setRepeatType(1)
-            ->setStartDate(new \DateTime());
+            ->setStartDate(new \DateTimeImmutable());
         $res = $applicationUrlGen->createWhitebophirLink($room, true);
         $repeater = $room->getRepeater();
         $token = $tokenService->createJwt($room, true);

--- a/tests/JitsiComponentSelector/CallerControllerSipVideoTest.php
+++ b/tests/JitsiComponentSelector/CallerControllerSipVideoTest.php
@@ -76,11 +76,11 @@ class CallerControllerSipVideoTest extends WebTestCase
         $room->setLobby(true);
         $status = new RoomStatus();
         $status->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $manager->flush();
 

--- a/tests/JitsiEvents/controller/JitsiEventSyncApiControllerTest.php
+++ b/tests/JitsiEvents/controller/JitsiEventSyncApiControllerTest.php
@@ -24,9 +24,9 @@ class JitsiEventSyncApiControllerTest extends WebTestCase
         $roomsStatus = new RoomStatus();
         $roomsStatus->setJitsiRoomId('123456|meet.jit.si')
             ->setCreated(true)
-            ->setUpdatedAt(new \DateTime())
-            ->setRoomCreatedAt(new \DateTime())
-        ->setCreatedAt(new \DateTime());
+            ->setUpdatedAt(new \DateTimeImmutable())
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+        ->setCreatedAt(new \DateTimeImmutable());
         $manager->persist($roomsStatus);
         $manager->flush();
 

--- a/tests/Join/JoinPublicLobbyTest.php
+++ b/tests/Join/JoinPublicLobbyTest.php
@@ -29,7 +29,7 @@ class JoinPublicLobbyTest extends WebTestCase
 
         $wu = new LobbyWaitungUser();
         $wu->setShowName('test Me Lobby WaitingUser');
-        $wu->setCreatedAt(new \DateTime())
+        $wu->setCreatedAt(new \DateTimeImmutable())
             ->setRoom($room)
             ->setType('b')
             ->setUid('lksdjflkdsjf');
@@ -90,7 +90,7 @@ class JoinPublicLobbyTest extends WebTestCase
 
         $wu = new LobbyWaitungUser();
         $wu->setShowName('test Me Lobby WaitingUser');
-        $wu->setCreatedAt(new \DateTime())
+        $wu->setCreatedAt(new \DateTimeImmutable())
             ->setRoom($room)
             ->setType('b')
             ->setUid('lksdjflkdsjf');

--- a/tests/Join/JoinPublicTest.php
+++ b/tests/Join/JoinPublicTest.php
@@ -98,8 +98,8 @@ class JoinPublicTest extends WebTestCase
         $userRepo = $this->getContainer()->get(UserRepository::class);
         $user = $userRepo->findOneBy(['email' => 'test@local3.de']);
         $room = $roomRepo->findOneBy(['name' => 'TestMeeting: 19']);
-        $room->setStart((new \DateTime())->modify('+2 hours'));
-        $room->setEnddate((new \DateTime())->modify('+4 hours'));
+        $room->setStart((new \DateTimeImmutable())->modify('+2 hours'));
+        $room->setEnddate((new \DateTimeImmutable())->modify('+4 hours'));
         $manager = $this->getContainer()->get(EntityManagerInterface::class);
         $manager->persist($room);
         $manager->flush();

--- a/tests/Join/OwnRoomJoinTest.php
+++ b/tests/Join/OwnRoomJoinTest.php
@@ -19,7 +19,7 @@ class OwnRoomJoinTest extends WebTestCase
         $client = static::createClient();
         $room = $this->getRoomByName('Room with Start and no Participants list');
     
-        $room->setStart((new \DateTime())->modify('+2 hours'));
+        $room->setStart((new \DateTimeImmutable())->modify('+2 hours'));
         $em = self::getContainer()->get(EntityManagerInterface::class);
         $em->persist($room);
         $em->flush();
@@ -34,7 +34,7 @@ class OwnRoomJoinTest extends WebTestCase
     {
         $client = static::createClient();
         $room = $this->getRoomByName('Room with Start and no Participants list');
-        $room->setStart((new \DateTime())->modify('+15min'));
+        $room->setStart((new \DateTimeImmutable())->modify('+15min'));
         $em = self::getContainer()->get(EntityManagerInterface::class);
         $em->persist($room);
         $em->flush();
@@ -53,7 +53,7 @@ class OwnRoomJoinTest extends WebTestCase
     {
         $client = static::createClient();
         $room = $this->getRoomByName('Room with Start and no Participants list');
-        $room->setStart((new \DateTime())->modify('+15min'));
+        $room->setStart((new \DateTimeImmutable())->modify('+15min'));
         $server = $room->getServer();
         $server->setLicenseKey(null);
         $em = self::getContainer()->get(EntityManagerInterface::class);
@@ -73,7 +73,7 @@ class OwnRoomJoinTest extends WebTestCase
     {
         $client = static::createClient();
         $room = $this->getRoomByName('Room with Start and no Participants list');
-        $room->setStart((new \DateTime())->modify('+15min'));
+        $room->setStart((new \DateTimeImmutable())->modify('+15min'));
         $server = $room->getServer();
         $em = self::getContainer()->get(EntityManagerInterface::class);
         $em->persist($room);
@@ -96,7 +96,7 @@ class OwnRoomJoinTest extends WebTestCase
         $user = $userRepo->findOneBy(['email' => 'test@local.de']);
         $client->loginUser($user);
         $room = $this->getRoomByName('Room with Start and no Participants list');
-        $room->setStart((new \DateTime())->modify('+15min'));
+        $room->setStart((new \DateTimeImmutable())->modify('+15min'));
         $server = $room->getServer();
         $em = self::getContainer()->get(EntityManagerInterface::class);
         $em->persist($room);
@@ -133,7 +133,7 @@ class OwnRoomJoinTest extends WebTestCase
         $manager->persist($room);
         $manager->flush();
 
-        $room->setStart((new \DateTime())->modify('+15min'));
+        $room->setStart((new \DateTimeImmutable())->modify('+15min'));
         $server = $room->getServer();
         $em = self::getContainer()->get(EntityManagerInterface::class);
         $em->persist($room);
@@ -162,13 +162,13 @@ class OwnRoomJoinTest extends WebTestCase
         $url = self::getContainer()->get(UrlGeneratorInterface::class);
         $room = $this->getRoomByName('Room with Start and no Participants list');
         $manager = $this->getContainer()->get(EntityManagerInterface::class);
-        $room->setStart((new \DateTime())->modify('+10min'));
+        $room->setStart((new \DateTimeImmutable())->modify('+10min'));
         $manager->persist($room);
         $manager->flush();
         $crawler = $client->request('GET', '/mywaiting/check/' . $room->getUid() . '/Test User 123/b');
         $this->assertResponseIsSuccessful();
         $this->assertEquals('{"error":true}', $client->getResponse()->getContent());
-        $room->setStart((new \DateTime())->modify('-10min'));
+        $room->setStart((new \DateTimeImmutable())->modify('-10min'));
         $manager->persist($room);
         $manager->flush();
         $urlGenService = self::getContainer()->get(RoomService::class);
@@ -192,13 +192,13 @@ class OwnRoomJoinTest extends WebTestCase
         $manager->persist($room);
         $manager->flush();
         $manager = $this->getContainer()->get(EntityManagerInterface::class);
-        $room->setStart((new \DateTime())->modify('+10min'));
+        $room->setStart((new \DateTimeImmutable())->modify('+10min'));
         $manager->persist($room);
         $manager->flush();
         $crawler = $client->request('GET', '/mywaiting/check/' . $room->getUid() . '/Test User 123/b');
         $this->assertResponseIsSuccessful();
         $this->assertEquals('{"error":true}', $client->getResponse()->getContent());
-        $room->setStart((new \DateTime())->modify('-10min'));
+        $room->setStart((new \DateTimeImmutable())->modify('-10min'));
         $manager->persist($room);
         $manager->flush();
         $urlGenService = self::getContainer()->get(RoomService::class);
@@ -217,7 +217,7 @@ class OwnRoomJoinTest extends WebTestCase
     {
         $client = static::createClient();
         $room = $this->getRoomByName('Room with Start and no Participants list and Lobby Activated');
-        $room->setStart((new \DateTime())->modify('+15min'));
+        $room->setStart((new \DateTimeImmutable())->modify('+15min'));
         $server = $room->getServer();
         $em = self::getContainer()->get(EntityManagerInterface::class);
         $em->persist($room);
@@ -248,7 +248,7 @@ class OwnRoomJoinTest extends WebTestCase
         $user = $userRepo->findOneBy(['email' => 'test@local.de']);
         $client->loginUser($user);
         $room = $this->getRoomByName('Room with Start and no Participants list and Lobby Activated');
-        $room->setStart((new \DateTime())->modify('+15min'));
+        $room->setStart((new \DateTimeImmutable())->modify('+15min'));
         $server = $room->getServer();
         $em = self::getContainer()->get(EntityManagerInterface::class);
         $em->persist($room);
@@ -300,7 +300,7 @@ class OwnRoomJoinTest extends WebTestCase
         $manager->persist($room);
         $manager->flush();
 
-        $room->setStart((new \DateTime())->modify('+15min'));
+        $room->setStart((new \DateTimeImmutable())->modify('+15min'));
         $server = $room->getServer();
         $em = self::getContainer()->get(EntityManagerInterface::class);
         $em->persist($room);

--- a/tests/LDAP/LdapUserServiceTest.php
+++ b/tests/LDAP/LdapUserServiceTest.php
@@ -261,8 +261,8 @@ class LdapUserServiceTest extends WebTestCase
         $room = new Rooms();
         $room->setModerator($user);
         $room->addUser($user);
-        $room->setStart(new \DateTime());
-        $room->setEnddate((new \DateTime())->modify('+60min'));
+        $room->setStart(new \DateTimeImmutable());
+        $room->setEnddate((new \DateTimeImmutable())->modify('+60min'));
         $room->setDuration(60);
         $room->setName('testRaum');
         $room->setServer($server);
@@ -522,7 +522,7 @@ class LdapUserServiceTest extends WebTestCase
         $lobbyUSer = new LobbyWaitungUser();
         $lobbyUSer->setUser($user);
         $lobbyUSer->setRoom($room);
-        $lobbyUSer->setCreatedAt(new \DateTime());
+        $lobbyUSer->setCreatedAt(new \DateTimeImmutable());
         $lobbyUSer->setUid('test');
         $lobbyUSer->setShowName('test');
         $lobbyUSer->setType('a');
@@ -530,7 +530,7 @@ class LdapUserServiceTest extends WebTestCase
         $em->flush();
 
         $wait = new Waitinglist();
-        $wait->setCreatedAt(new \DateTime());
+        $wait->setCreatedAt(new \DateTimeImmutable());
         $wait->setRoom($room);
         $wait->setUser($user);
 
@@ -539,7 +539,7 @@ class LdapUserServiceTest extends WebTestCase
 
         $user->addFavorite($room);
         $notification = new Notification();
-        $notification->setCreatedAt(new \DateTime());
+        $notification->setCreatedAt(new \DateTimeImmutable());
         $notification->setUser($user);
         $notification->setUrl('test');
         $notification->setText('test');
@@ -549,7 +549,7 @@ class LdapUserServiceTest extends WebTestCase
 
         $callerID = new CallerId();
         $callerID->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setUser($user)
             ->setCallerId('tesstId');
         $em->persist($callerID);

--- a/tests/Lobby/Controller/LobbyModeratorControllerTest.php
+++ b/tests/Lobby/Controller/LobbyModeratorControllerTest.php
@@ -49,7 +49,7 @@ class LobbyModeratorControllerTest extends WebTestCase
         $this->assertResponseIsSuccessful();
         $lobbyUser = new LobbyWaitungUser();
         $lobbyUser->setRoom($room);
-        $lobbyUser->setCreatedAt(new \DateTime());
+        $lobbyUser->setCreatedAt(new \DateTimeImmutable());
         $lobbyUser->setUser($user2);
         $lobbyUser->setShowName($user2->getFirstName() . ' ' . $user2->getLastName());
         $lobbyUser->setType('a');
@@ -106,7 +106,7 @@ class LobbyModeratorControllerTest extends WebTestCase
         $lobbyUser = new LobbyWaitungUser();
         $lobbyUser->setRoom($room);
         $lobbyUser->setType('a');
-        $lobbyUser->setCreatedAt(new \DateTime());
+        $lobbyUser->setCreatedAt(new \DateTimeImmutable());
         $lobbyUser->setUser($user2);
         $lobbyUser->setUid('lkdsjhflkjlkdsjflkjdslkjflkjdslkjf');
         $lobbyUser->setShowName($user2->getFirstName() . ' ' . $user2->getLastName());
@@ -151,7 +151,7 @@ class LobbyModeratorControllerTest extends WebTestCase
         $lobbyUser = new LobbyWaitungUser();
         $lobbyUser->setRoom($room);
         $lobbyUser->setType('a');
-        $lobbyUser->setCreatedAt(new \DateTime());
+        $lobbyUser->setCreatedAt(new \DateTimeImmutable());
         $lobbyUser->setUser($user2);
         $lobbyUser->setUid('lkdsjhflkjlkdsjflkjdslkjflkjdslkjf');
         $lobbyUser->setShowName($user2->getFirstName() . ' ' . $user2->getLastName());
@@ -227,7 +227,7 @@ class LobbyModeratorControllerTest extends WebTestCase
         $lobbyUser = new LobbyWaitungUser();
         $lobbyUser->setType('a');
         $lobbyUser->setRoom($room);
-        $lobbyUser->setCreatedAt(new \DateTime());
+        $lobbyUser->setCreatedAt(new \DateTimeImmutable());
         $lobbyUser->setUser($user2);
         $lobbyUser->setUid('lkdsjhflkjlkdsjflkjdslkjflkjdslkjf');
         $lobbyUser->setShowName($user2->getFirstName() . ' ' . $user2->getLastName());
@@ -235,7 +235,7 @@ class LobbyModeratorControllerTest extends WebTestCase
         $lobbyUser2 = new LobbyWaitungUser();
         $lobbyUser2->setType('a');
         $lobbyUser2->setRoom($room);
-        $lobbyUser2->setCreatedAt(new \DateTime());
+        $lobbyUser2->setCreatedAt(new \DateTimeImmutable());
         $lobbyUser2->setUser($moderator);
         $lobbyUser2->setUid('lkdsjhflkjlkdsfghhgfjflkjdslkjflkjdslkjf');
         $lobbyUser2->setShowName($moderator->getFirstName() . ' ' . $moderator->getLastName());

--- a/tests/Lobby/Service/CleanUpLobbyServiceTest.php
+++ b/tests/Lobby/Service/CleanUpLobbyServiceTest.php
@@ -53,14 +53,14 @@ class CleanUpLobbyServiceTest extends KernelTestCase
         $lobbyRepoUser = $lobbyRepo->findAll();
         foreach ($lobbyRepoUser as $data) {
             $callerID = new CallerId();
-            $callerID->setCreatedAt(new \DateTime());
+            $callerID->setCreatedAt(new \DateTimeImmutable());
             $callerID->setCallerId('test');
             $callerID->setRoom($data->getRoom());
             $callerID->setUser($data->getUser());
             $session = new CallerSession();
             $session->setAuthOk(false);
             $session->setCallerId('sdffsd');
-            $session->setCreatedAt(new \DateTime());
+            $session->setCreatedAt(new \DateTimeImmutable());
             $session->setShowName('test');
             $session->setSessionId('test');
             $session->setCaller($callerID);

--- a/tests/Lobby/Service/LobbyToParticipantsTest.php
+++ b/tests/Lobby/Service/LobbyToParticipantsTest.php
@@ -60,7 +60,7 @@ class LobbyToParticipantsTest extends KernelTestCase
         $lobbyUser->setUser($user2);
         $lobbyUser->setRoom($room);
         $lobbyUser->setUid('lkjhdslkfjhdskjhfkds');
-        $lobbyUser->setCreatedAt(new \DateTime());
+        $lobbyUser->setCreatedAt(new \DateTimeImmutable());
         $lobbyUser->setShowName($user2->getFirstName() . ' ' . $user2->getLastName());
         $manager = self::getContainer()->get(EntityManagerInterface::class);
         $manager->persist($lobbyUser);
@@ -113,7 +113,7 @@ class LobbyToParticipantsTest extends KernelTestCase
         $lobbyUser->setUser($user2);
         $lobbyUser->setRoom($room);
         $lobbyUser->setUid('lkjhdslkfjhdskjhfkds');
-        $lobbyUser->setCreatedAt(new \DateTime());
+        $lobbyUser->setCreatedAt(new \DateTimeImmutable());
         $lobbyUser->setShowName($user2->getFirstName() . ' ' . $user2->getLastName());
         $manager = self::getContainer()->get(EntityManagerInterface::class);
         $server = $lobbyUser->getRoom()->getServer();
@@ -139,7 +139,7 @@ class LobbyToParticipantsTest extends KernelTestCase
         $lobbyUser->setUser($user2);
         $lobbyUser->setRoom($room);
         $lobbyUser->setUid('lkjhdslkfjhdskjhfkds');
-        $lobbyUser->setCreatedAt(new \DateTime());
+        $lobbyUser->setCreatedAt(new \DateTimeImmutable());
         $lobbyUser->setShowName($user2->getFirstName() . ' ' . $user2->getLastName());
         $manager = self::getContainer()->get(EntityManagerInterface::class);
         $manager->persist($lobbyUser);
@@ -193,7 +193,7 @@ class LobbyToParticipantsTest extends KernelTestCase
         $lobbyUser->setUser($user2);
         $lobbyUser->setRoom($room);
         $lobbyUser->setUid('lkjhdslkfjhdskjhfkds');
-        $lobbyUser->setCreatedAt(new \DateTime());
+        $lobbyUser->setCreatedAt(new \DateTimeImmutable());
         $lobbyUser->setShowName($user2->getFirstName() . ' ' . $user2->getLastName());
         $manager = self::getContainer()->get(EntityManagerInterface::class);
         $manager->persist($lobbyUser);

--- a/tests/Lobby/Service/LobbyUtilsTest.php
+++ b/tests/Lobby/Service/LobbyUtilsTest.php
@@ -33,18 +33,18 @@ class LobbyUtilsTest extends KernelTestCase
         $em = self::getContainer()->get(EntityManagerInterface::class);
         $lobbyWaitingUSerRepo = self::getContainer()->get(LobbyWaitungUserRepository::class);
         $lobbyWaitinguser = new LobbyWaitungUser();
-        $lobbyWaitinguser->setUser($user2)->setRoom($room)->setShowName('test 123')->setCreatedAt(new \DateTime())->setUid('lkjsdjfjdskjf')->setType('a');
+        $lobbyWaitinguser->setUser($user2)->setRoom($room)->setShowName('test 123')->setCreatedAt(new \DateTimeImmutable())->setUid('lkjsdjfjdskjf')->setType('a');
         $room->addLobbyWaitungUser($lobbyWaitinguser);
         $em->persist($room);
         $em->persist($lobbyWaitinguser);
         $em->flush();
 
         $lobbyWaitinguser = new LobbyWaitungUser();
-        $lobbyWaitinguser->setUser($user3)->setRoom($room)->setShowName('test 1231')->setCreatedAt(new \DateTime())->setUid('lkjsdjfjdskjf')->setType('a');
+        $lobbyWaitinguser->setUser($user3)->setRoom($room)->setShowName('test 1231')->setCreatedAt(new \DateTimeImmutable())->setUid('lkjsdjfjdskjf')->setType('a');
 
 
         $callerId = new CallerId();
-        $callerId->setCreatedAt(new \DateTime())->setRoom($room)->setUser($user3)->setCallerId('testPIN');
+        $callerId->setCreatedAt(new \DateTimeImmutable())->setRoom($room)->setUser($user3)->setCallerId('testPIN');
         $em->persist($callerId);
         $em->flush();
 
@@ -54,7 +54,7 @@ class LobbyUtilsTest extends KernelTestCase
             ->setLobbyWaitingUser($lobbyWaitinguser)
             ->setAuthOk(true)
             ->setCallerId('test123')
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setShowName('test')
             ->setSessionId('test');
         $lobbyWaitinguser->setCallerSession($callerSession);

--- a/tests/Mailer/MailerServiceTest.php
+++ b/tests/Mailer/MailerServiceTest.php
@@ -31,22 +31,22 @@ class MailerServiceTest extends KernelTestCase
             ->setSmtpUsername('username')
             ->setSmtpEmail('local@local.de');
         $this->userSender = new User();
-        $this->userSender->setCreatedAt(new \DateTime())
+        $this->userSender->setCreatedAt(new \DateTimeImmutable())
             ->setEmail('test@test.de')
             ->setFirstName('testVorname')
             ->setLastName('testLastName')
             ->setTimeZone('Europe/Berlin')
             ->setKeycloakId('testId')
-            ->setLastLogin(new \DateTime())
+            ->setLastLogin(new \DateTimeImmutable())
             ->setUsername('test@test.de');
         $this->userReciever = new User();
-        $this->userReciever->setCreatedAt(new \DateTime())
+        $this->userReciever->setCreatedAt(new \DateTimeImmutable())
             ->setEmail('test2@test.de')
             ->setFirstName('testVorname2')
             ->setLastName('testLastName2')
             ->setTimeZone('Europe/Berlin')
             ->setKeycloakId('testId2')
-            ->setLastLogin(new \DateTime())
+            ->setLastLogin(new \DateTimeImmutable())
             ->setUsername('test2@test.de');
         $this->room = new Rooms();
         $this->room->setModerator($this->userSender)
@@ -56,9 +56,9 @@ class MailerServiceTest extends KernelTestCase
             ->setAgenda('testagenda')
             ->setTimeZone('Europe/Berlin')
             ->setServer($this->server)
-            ->setStart(new \DateTime())
+            ->setStart(new \DateTimeImmutable())
             ->setDuration(60)
-            ->setEnddate((new \DateTime())->modify('+60min'));
+            ->setEnddate((new \DateTimeImmutable())->modify('+60min'));
     }
 
     public function testCreateMailer(): void

--- a/tests/Permission/PermissionChangeServiceTest.php
+++ b/tests/Permission/PermissionChangeServiceTest.php
@@ -86,7 +86,7 @@ class PermissionChangeServiceTest extends KernelTestCase
         $this->assertEquals(false, $changePermissionService->toggleLobbyModerator($testUser, $testUser, $room));
         $userRoomRepo = self::getContainer()->get(RoomsUserRepository::class);
         $userRoom = $userRoomRepo->findOneBy(['user' => $testUser, 'room' => $room]);
-        $lobbyWaitingUSer = (new LobbyWaitungUser())->setRoom($room)->setUser($testUser)->setShowName('test123')->setType('a')->setUid('kjdshfkhds')->setCreatedAt(new \DateTime());
+        $lobbyWaitingUSer = (new LobbyWaitungUser())->setRoom($room)->setUser($testUser)->setShowName('test123')->setType('a')->setUid('kjdshfkhds')->setCreatedAt(new \DateTimeImmutable());
         $em = self::getContainer()->get(EntityManagerInterface::class);
         $em->persist($lobbyWaitingUSer);
         $em->flush();

--- a/tests/Repeater/RepeaterControllerTest.php
+++ b/tests/Repeater/RepeaterControllerTest.php
@@ -38,7 +38,7 @@ class RepeaterControllerTest extends WebTestCase
         $rooms = $roomRepo->findBy(['name' => 'TestMeeting: 0'],['start'=>'ASC']);
         self::assertEquals(11, sizeof($rooms));
         $start = $room->getStart();
-        $start->setTime($start->format('H'), $start->format('i'), 0);
+        $start = $start->setTime($start->format('H'), $start->format('i'), 0);
 
         foreach ($rooms as $data) {
 
@@ -46,7 +46,7 @@ class RepeaterControllerTest extends WebTestCase
             if ($data->getRepeater()) {
 
                 self::assertEquals($start, $data->getStart());
-                $start->modify('+1day');
+                $start = $start->modify('+1day');
             } else {
                 self::assertEquals($data->getStart(), $data->getRepeaterProtoype()->getStartDate());
             }
@@ -67,12 +67,12 @@ class RepeaterControllerTest extends WebTestCase
 
         $rooms = $roomRepo->findBy(['name' => 'TestMeeting: 0'],['start'=>'ASC']);
         self::assertEquals(11, sizeof($rooms));
-        $start = new \DateTime('2022-04-10T12:00:00');
-        $start->setTime($start->format('H'), $start->format('i'), 0);
+        $start = new \DateTimeImmutable('2022-04-10T12:00:00');
+        $start = $start->setTime($start->format('H'), $start->format('i'), 0);
         foreach ($rooms as $data) {
             if ($data->getRepeater()) {
                 self::assertEquals($start, $data->getStart());
-                $start->modify('+1day');
+                $start = $start->modify('+1day');
             } else {
                 self::assertEquals($data->getStart(), $data->getRepeaterProtoype()->getStartDate());
             }
@@ -97,11 +97,11 @@ class RepeaterControllerTest extends WebTestCase
 
         $rooms = $roomRepo->findBy(['name' => 'TestMeeting: 0'],['start'=>'ASC']);
         self::assertEquals(4, sizeof($rooms));
-        $start = new \DateTime('2022-04-10T12:00:00');
+        $start = new \DateTimeImmutable('2022-04-10T12:00:00');
         foreach ($rooms as $data) {
             if ($data->getRepeater()) {
                 self::assertEquals($start, $data->getStart());
-                $start->modify('+3days');
+                $start = $start->modify('+3days');
             } else {
                 self::assertEquals($data->getStart(), $data->getRepeaterProtoype()->getStartDate());
             }

--- a/tests/Repeater/RepeaterServiceTest.php
+++ b/tests/Repeater/RepeaterServiceTest.php
@@ -30,9 +30,9 @@ class RepeaterServiceTest extends KernelTestCase
         self::assertTrue($repeaterService->checkData($repeat));
         $repeaterService->createNewRepeater($repeat);
         self::assertEquals(3, sizeof($repeat->getRooms()));
-        self::assertEquals(new \DateTime('2021-01-15T15:00'), $repeat->getRooms()[0]->getStart());
-        self::assertEquals(new \DateTime('2021-01-16T15:00'), $repeat->getRooms()[1]->getStart());
-        self::assertEquals(new \DateTime('2021-01-17T15:00'), $repeat->getRooms()[2]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-15T15:00'), $repeat->getRooms()[0]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-16T15:00'), $repeat->getRooms()[1]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-17T15:00'), $repeat->getRooms()[2]->getStart());
         self::assertEquals(3, sizeof($repeat->getRooms()[0]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[1]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[2]->getUser()));
@@ -54,9 +54,9 @@ class RepeaterServiceTest extends KernelTestCase
         self::assertTrue($repeaterService->checkData($repeat));
         $repeaterService->createNewRepeater($repeat);
         self::assertEquals(3, sizeof($repeat->getRooms()));
-        self::assertEquals(new \DateTime('2021-01-15T15:00'), $repeat->getRooms()[0]->getStart());
-        self::assertEquals(new \DateTime('2021-01-22T15:00'), $repeat->getRooms()[1]->getStart());
-        self::assertEquals(new \DateTime('2021-01-29T15:00'), $repeat->getRooms()[2]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-15T15:00'), $repeat->getRooms()[0]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-22T15:00'), $repeat->getRooms()[1]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-29T15:00'), $repeat->getRooms()[2]->getStart());
         self::assertEquals(3, sizeof($repeat->getRooms()[0]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[1]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[2]->getUser()));
@@ -78,9 +78,9 @@ class RepeaterServiceTest extends KernelTestCase
         self::assertTrue($repeaterService->checkData($repeat));
         $repeaterService->createNewRepeater($repeat);
         self::assertEquals(3, sizeof($repeat->getRooms()));
-        self::assertEquals(new \DateTime('2021-01-15T15:00'), $repeat->getRooms()[0]->getStart());
-        self::assertEquals(new \DateTime('2021-02-15T15:00'), $repeat->getRooms()[1]->getStart());
-        self::assertEquals(new \DateTime('2021-03-15T15:00'), $repeat->getRooms()[2]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-15T15:00'), $repeat->getRooms()[0]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-02-15T15:00'), $repeat->getRooms()[1]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-03-15T15:00'), $repeat->getRooms()[2]->getStart());
         self::assertEquals(3, sizeof($repeat->getRooms()[0]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[1]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[2]->getUser()));
@@ -104,9 +104,9 @@ class RepeaterServiceTest extends KernelTestCase
         self::assertTrue($repeaterService->checkData($repeat));
         $repeaterService->createNewRepeater($repeat);
         self::assertEquals(3, sizeof($repeat->getRooms()));
-        self::assertEquals(new \DateTime('2021-02-01T15:00'), $repeat->getRooms()[0]->getStart());
-        self::assertEquals(new \DateTime('2021-03-01T15:00'), $repeat->getRooms()[1]->getStart());
-        self::assertEquals(new \DateTime('2021-04-05T15:00'), $repeat->getRooms()[2]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-02-01T15:00'), $repeat->getRooms()[0]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-03-01T15:00'), $repeat->getRooms()[1]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-04-05T15:00'), $repeat->getRooms()[2]->getStart());
         self::assertEquals(3, sizeof($repeat->getRooms()[0]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[1]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[2]->getUser()));
@@ -132,9 +132,9 @@ class RepeaterServiceTest extends KernelTestCase
         $repeaterService->createNewRepeater($repeat);
         self::assertEquals(3, sizeof($repeat->getRooms()));
         self::assertEquals(3, sizeof($repeat->getRooms()));
-        self::assertEquals(new \DateTime('2021-01-04T15:00'), $repeat->getRooms()[0]->getStart());
-        self::assertEquals(new \DateTime('2021-02-01T15:00'), $repeat->getRooms()[1]->getStart());
-        self::assertEquals(new \DateTime('2021-03-01T15:00'), $repeat->getRooms()[2]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-04T15:00'), $repeat->getRooms()[0]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-02-01T15:00'), $repeat->getRooms()[1]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-03-01T15:00'), $repeat->getRooms()[2]->getStart());
         self::assertEquals(3, sizeof($repeat->getRooms()[0]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[1]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[2]->getUser()));
@@ -156,9 +156,9 @@ class RepeaterServiceTest extends KernelTestCase
         self::assertTrue($repeaterService->checkData($repeat));
         $repeaterService->createNewRepeater($repeat);
         self::assertEquals(3, sizeof($repeat->getRooms()));
-        self::assertEquals(new \DateTime('2021-01-15T15:00'), $repeat->getRooms()[0]->getStart());
-        self::assertEquals(new \DateTime('2022-01-15T15:00'), $repeat->getRooms()[1]->getStart());
-        self::assertEquals(new \DateTime('2023-01-15T15:00'), $repeat->getRooms()[2]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-15T15:00'), $repeat->getRooms()[0]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2022-01-15T15:00'), $repeat->getRooms()[1]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2023-01-15T15:00'), $repeat->getRooms()[2]->getStart());
         self::assertEquals(3, sizeof($repeat->getRooms()[0]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[1]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[2]->getUser()));
@@ -184,9 +184,9 @@ class RepeaterServiceTest extends KernelTestCase
         self::assertTrue($repeaterService->checkData($repeat));
         $repeaterService->createNewRepeater($repeat);
         self::assertEquals(3, sizeof($repeat->getRooms()));
-        self::assertEquals(new \DateTime('2022-01-03T15:00'), $repeat->getRooms()[0]->getStart());
-        self::assertEquals(new \DateTime('2023-01-02T15:00'), $repeat->getRooms()[1]->getStart());
-        self::assertEquals(new \DateTime('2024-01-01T15:00'), $repeat->getRooms()[2]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2022-01-03T15:00'), $repeat->getRooms()[0]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2023-01-02T15:00'), $repeat->getRooms()[1]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2024-01-01T15:00'), $repeat->getRooms()[2]->getStart());
         self::assertEquals(3, sizeof($repeat->getRooms()[0]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[1]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[2]->getUser()));
@@ -212,9 +212,9 @@ class RepeaterServiceTest extends KernelTestCase
         self::assertTrue($repeaterService->checkData($repeat));
         $repeaterService->createNewRepeater($repeat);
         self::assertEquals(3, sizeof($repeat->getRooms()));
-        self::assertEquals(new \DateTime('2021-01-04T15:00'), $repeat->getRooms()[0]->getStart());
-        self::assertEquals(new \DateTime('2022-01-03T15:00'), $repeat->getRooms()[1]->getStart());
-        self::assertEquals(new \DateTime('2023-01-02T15:00'), $repeat->getRooms()[2]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-04T15:00'), $repeat->getRooms()[0]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2022-01-03T15:00'), $repeat->getRooms()[1]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2023-01-02T15:00'), $repeat->getRooms()[2]->getStart());
         self::assertEquals(3, sizeof($repeat->getRooms()[0]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[1]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[2]->getUser()));
@@ -236,9 +236,9 @@ class RepeaterServiceTest extends KernelTestCase
         $repeat->setRepeaterDays(1);
         $repeaterService->createNewRepeater($repeat);
         self::assertEquals(3, sizeof($repeat->getRooms()));
-        self::assertEquals(new \DateTime('2021-01-15T15:00'), $repeat->getRooms()[0]->getStart());
-        self::assertEquals(new \DateTime('2021-01-16T15:00'), $repeat->getRooms()[1]->getStart());
-        self::assertEquals(new \DateTime('2021-01-17T15:00'), $repeat->getRooms()[2]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-15T15:00'), $repeat->getRooms()[0]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-16T15:00'), $repeat->getRooms()[1]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-17T15:00'), $repeat->getRooms()[2]->getStart());
         self::assertEquals(3, sizeof($repeat->getRooms()[0]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[1]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[2]->getUser()));
@@ -271,9 +271,9 @@ class RepeaterServiceTest extends KernelTestCase
         $manager->flush();
         $repeaterService->addUserRepeat($repeat);
         self::assertEquals(3, sizeof($repeat->getRooms()));
-        self::assertEquals(new \DateTime('2021-01-15T15:00'), $repeat->getRooms()[0]->getStart());
-        self::assertEquals(new \DateTime('2021-01-16T15:00'), $repeat->getRooms()[1]->getStart());
-        self::assertEquals(new \DateTime('2021-01-17T15:00'), $repeat->getRooms()[2]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-15T15:00'), $repeat->getRooms()[0]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-16T15:00'), $repeat->getRooms()[1]->getStart());
+        self::assertEquals(new \DateTimeImmutable('2021-01-17T15:00'), $repeat->getRooms()[2]->getStart());
         self::assertEquals(3, sizeof($repeat->getRooms()[0]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[1]->getUser()));
         self::assertEquals(3, sizeof($repeat->getRooms()[2]->getUser()));
@@ -285,7 +285,7 @@ class RepeaterServiceTest extends KernelTestCase
         $roomNew = $repTmp->getPrototyp();
         $roomNew->setRepeaterProtoype($repTmp);
         $roomNew->setDuration(90);
-        $roomNew->setStart(new \DateTime('2021-01-20T18:00'));
+        $roomNew->setStart(new \DateTimeImmutable('2021-01-20T18:00'));
         $rep = $repeaterService->prepareRepeater($roomNew);
         self::assertEquals('2021-01-20T18:00', $rep->getStartDate()->format('Y-m-d') . 'T' . $rep->getStartDate()->format('H:i'));
         $rep = $repeaterService->replaceRooms($roomNew);
@@ -294,10 +294,10 @@ class RepeaterServiceTest extends KernelTestCase
         self::assertEquals('Sie haben erfolgreich einen Serientermin bearbeitet.', $rep);
         self::assertEquals(3, sizeof($repTmp->getRooms()));
 
-        $date = new \DateTime('2021-01-20T18:00');
+        $date = new \DateTimeImmutable('2021-01-20T18:00');
         foreach ($repTmp->getRooms() as $data) {
             self::assertEquals($date, $data->getStart());
-            $date->modify('+1day');
+            $date = $date->modify('+1day');
             self::assertEquals(3, sizeof($data->getUser()));
             self::assertEquals(3, sizeof($data->getCallerIds()));
             self::assertNotNull($data->getCallerRoom());
@@ -326,9 +326,9 @@ class RepeaterServiceTest extends KernelTestCase
 
     private function changeStart(Rooms $rooms, $startDate)
     {
-        $rooms->setStart(new \DateTime($startDate));
+        $rooms->setStart(new \DateTimeImmutable($startDate));
         $endDate = clone $rooms->getStart();
-        $endDate->modify('+' . $rooms->getDuration() . 'min');
+        $endDate = $endDate->modify('+' . $rooms->getDuration() . 'min');
         $rooms->setEnddate($endDate);
         return $rooms;
     }

--- a/tests/Rooms/Controller/RoomNewTest.php
+++ b/tests/Rooms/Controller/RoomNewTest.php
@@ -54,7 +54,7 @@ class RoomNewTest extends WebTestCase
         $this->assertJsonStringEqualsJsonString(json_encode(['error' => true, 'messages' => ['Fehler, das Startdatum und das Enddatum liegen in der Vergangenheit.']]), $client->getResponse()->getContent());
         $form['room[server]'] = $server->getId();
         $form['room[name]'] = '198273987321';
-        $form['room[start]'] = (new \DateTime())->format('Y-m-d H:i:s');
+        $form['room[start]'] = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
         $form['room[duration]'] = "60";
         $client->submit($form);
         $room = (static::getContainer()->get(RoomsRepository::class))->findOneBy(['name' => 198273987321]);
@@ -113,7 +113,7 @@ class RoomNewTest extends WebTestCase
         $form = $buttonCrawlerNode->form();
         $form['room[server]'] = $server->getId();
         $form['room[name]'] = '198273987321';
-        $form['room[start]'] = (new \DateTime())->format('Y-m-d H:i:s');
+        $form['room[start]'] = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
         $form['room[duration]'] = "60";
         $client->submit($form);
         $roomRepo = static::getContainer()->get(RoomsRepository::class);
@@ -173,7 +173,7 @@ class RoomNewTest extends WebTestCase
         $form = $buttonCrawlerNode->form();
         $form['room[server]'] = $server->getId();
         $form['room[name]'] = '198273987321';
-        $form['room[start]'] = (new \DateTime())->modify('+1hour')->format('Y-m-d H:i:s');
+        $form['room[start]'] = (new \DateTimeImmutable())->modify('+1hour')->format('Y-m-d H:i:s');
         $form['room[duration]'] = "60";
         $client->submit($form);
         $roomRepo = static::getContainer()->get(RoomsRepository::class);
@@ -208,7 +208,7 @@ class RoomNewTest extends WebTestCase
         $form = $buttonCrawlerNode->form();
         $form['room[server]'] = $server->getId();
         $form['room[name]'] = '';
-        $form['room[start]'] = (new \DateTime())->modify('+2hours')->format('Y-m-d H:i:s');
+        $form['room[start]'] = (new \DateTimeImmutable())->modify('+2hours')->format('Y-m-d H:i:s');
         $form['room[duration]'] = "60";
         $client->submit($form);
         $this->assertJsonStringEqualsJsonString(json_encode(['error' => true, 'messages' => ['Fehler, bitte den Namen angeben.']]), $client->getResponse()->getContent());
@@ -233,7 +233,7 @@ class RoomNewTest extends WebTestCase
 
         $form['room[server]'] = $server->getId();
         $form['room[name]'] = '765456654456';
-        $form['room[start]'] = (new \DateTime())->format('Y-m-d H:i:s');
+        $form['room[start]'] = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
         $form['room[duration]'] = "60";
 
         $client->submit($form);
@@ -277,7 +277,7 @@ class RoomNewTest extends WebTestCase
         $form = $buttonCrawlerNode->form();
         $form['room[server]'] = $server->getId();
         $form['room[name]'] = '198273987321';
-        $form['room[start]'] = (new \DateTime())->modify('+1hour')->format('Y-m-d H:i:s');
+        $form['room[start]'] = (new \DateTimeImmutable())->modify('+1hour')->format('Y-m-d H:i:s');
         $form['room[duration]'] = "60";
         $client->submit($form);
         $roomRepo = static::getContainer()->get(RoomsRepository::class);
@@ -312,7 +312,7 @@ class RoomNewTest extends WebTestCase
         $buttonCrawlerNode = $crawler->selectButton('Speichern');
         $form = $buttonCrawlerNode->form();
         $form['room[name]'] = 'Roome Clone';
-        $form['room[start]'] = (new \DateTime())->modify('+2hours')->format('Y-m-d H:i:s');
+        $form['room[start]'] = (new \DateTimeImmutable())->modify('+2hours')->format('Y-m-d H:i:s');
 
         $client->submit($form);
         $room = $roomRepo->findOneBy(['name' => 'Roome Clone']);
@@ -354,7 +354,7 @@ class RoomNewTest extends WebTestCase
         $form['room[server]'] = $server->getId();
         $form['room[name]'] = '198273987321';
         $form['room[agenda]'] = 'this is an agenda for this meeting';
-        $form['room[start]'] = (new \DateTime())->format('Y-m-d H:i:s');
+        $form['room[start]'] = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
         $form['room[duration]'] = "60";
         $client->submit($form);
         $roomRepo = static::getContainer()->get(RoomsRepository::class);
@@ -441,8 +441,8 @@ class RoomNewTest extends WebTestCase
             ->setUidParticipant(md5(uniqid()))
             ->setSequence(0)
             ->setDuration(60)
-            ->setStart(new \DateTime())
-            ->setEnddate((new \DateTime())->modify('+60min'))
+            ->setStart(new \DateTimeImmutable())
+            ->setEnddate((new \DateTimeImmutable())->modify('+60min'))
             ->setScheduleMeeting(false)
             ->setTimeZone('Europe/Berlin')
             ->setSlug('test');
@@ -451,11 +451,11 @@ class RoomNewTest extends WebTestCase
 
         $status = new RoomStatus();
         $status->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test-running-room')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $em->persist($status);
         $em->flush();
 
@@ -463,7 +463,7 @@ class RoomNewTest extends WebTestCase
         $participant->setRoomStatus($status)
             ->setParticipantId('participant-1')
             ->setParticipantName('Participant One')
-            ->setEnteredRoomAt(new \DateTime())
+            ->setEnteredRoomAt(new \DateTimeImmutable())
             ->setInRoom(true);
         $em->persist($participant);
         $em->flush();

--- a/tests/Rooms/Service/RemoveRoomTest.php
+++ b/tests/Rooms/Service/RemoveRoomTest.php
@@ -33,14 +33,14 @@ class RemoveRoomTest extends KernelTestCase
         $lobbyWatingUSer->setUser($user);
         $lobbyWatingUSer->setRoom($room);
         $lobbyWatingUSer->setType('a');
-        $lobbyWatingUSer->setCreatedAt(new \DateTime());
+        $lobbyWatingUSer->setCreatedAt(new \DateTimeImmutable());
         $lobbyWatingUSer->setShowName('test');
         $lobbyWatingUSer->setUid('test');
         $modSId = null;
         foreach ($room->getUser() as $data) {
             $callerID = new CallerId();
             $callerID->setRoom($room);
-            $callerID->setCreatedAt(new \DateTime());
+            $callerID->setCreatedAt(new \DateTimeImmutable());
             $callerID->setUser($data);
             $callerID->setCallerId('test123');
             if ($data == $room->getModerator()) {
@@ -52,7 +52,7 @@ class RemoveRoomTest extends KernelTestCase
         $callerSession->setAuthOk(false);
         $callerSession->setCallerId('1234');
         $callerSession->setCaller($modSId);
-        $callerSession->setCreatedAt(new \DateTime());
+        $callerSession->setCreatedAt(new \DateTimeImmutable());
         $callerSession->setSessionId('test');
         $callerSession->setShowName('test');
         $callerSession->setLobbyWaitingUser($lobbyWatingUSer);
@@ -70,7 +70,7 @@ class RemoveRoomTest extends KernelTestCase
 
         $wait = new Waitinglist();
         $wait->setUser($user);
-        $wait->setCreatedAt(new \DateTime());
+        $wait->setCreatedAt(new \DateTimeImmutable());
         $wait->setRoom($room);
         $em->persist($wait);
         $em->flush();

--- a/tests/Rooms/Service/RoomAddServiceTest.php
+++ b/tests/Rooms/Service/RoomAddServiceTest.php
@@ -429,7 +429,7 @@ class RoomAddServiceTest extends KernelTestCase
         $callerId = new CallerId();
         $callerId->setUser($user)
             ->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setCallerId('kjdshfsd');
         $manager->persist($callerId);
         $manager->flush();
@@ -452,7 +452,7 @@ class RoomAddServiceTest extends KernelTestCase
             ->setUid('ksjdhkjfhdsf')
             ->setInvitedFrom($room->getModerator())
             ->setUser($user)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setRoom($room)
             ->setLeftRetries(2);
         $user->addCalloutSession($calloutSession);
@@ -490,7 +490,7 @@ class RoomAddServiceTest extends KernelTestCase
         $callerId = new CallerId();
         $callerId->setUser($user)
             ->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setCallerId('kjdshfsd');
         $manager->persist($callerId);
         $manager->flush();

--- a/tests/Rooms/Service/RoomCheckServiceTest.php
+++ b/tests/Rooms/Service/RoomCheckServiceTest.php
@@ -15,7 +15,7 @@ class RoomCheckServiceTest extends KernelTestCase
         $this->assertSame('test', $kernel->getEnvironment());
         $checkService = self::getContainer()->get(RoomCheckService::class);
         $room = new Rooms();
-//        $room->setStart(new \DateTime());
+//        $room->setStart(new \DateTimeImmutable());
 //        $room->setDuration(60);
 //        $room->setPersistantRoom(true);
         $error = [];
@@ -25,28 +25,28 @@ class RoomCheckServiceTest extends KernelTestCase
         $error = [];
         $checkService->checkRoom($room, $error);
         self::assertEquals(['Fehler, bitte das Startdatum eingeben.'], $error);
-        $room->setStart(new \DateTime());
+        $room->setStart(new \DateTimeImmutable());
         $room->setDuration(60);
         $error = [];
         $checkService->checkRoom($room, $error);
         self::assertEquals([], $error);
         $error = [];
-        $room->setStart((new \DateTime())->modify('-30min'));
+        $room->setStart((new \DateTimeImmutable())->modify('-30min'));
         $room->setDuration(60);
         $checkService->checkRoom($room, $error);
         self::assertEquals([], $error);
         $error = [];
-        $room->setStart((new \DateTime())->modify('-70min'));
+        $room->setStart((new \DateTimeImmutable())->modify('-70min'));
         $room->setDuration(60);
         $checkService->checkRoom($room, $error);
         self::assertEquals(['Fehler, das Startdatum und das Enddatum liegen in der Vergangenheit.'], $error);
 
         $error = [];
-        $room->setStart((new \DateTime()));
+        $room->setStart((new \DateTimeImmutable()));
         $room->setDuration(60);
         $checkService->checkRoom($room, $error);
         self::assertEquals([], $error);
-        self::assertEquals((new \DateTime())->modify('+60min')->format('H:i:s'), $room->getEnddate()->format('H:i:s'));
+        self::assertEquals((new \DateTimeImmutable())->modify('+60min')->format('H:i:s'), $room->getEnddate()->format('H:i:s'));
         self::assertStringStartsNotWith('test123-', $room->getUid());
         self::assertStringStartsNotWith('test123-', (string)$room->getSlug());
         $error = [];
@@ -62,7 +62,7 @@ class RoomCheckServiceTest extends KernelTestCase
         self::assertStringStartsWith('test123-', $room->getSlug());
 
 
-        $nowGermany = new \DateTime('now', new \DateTimeZone('Europe/Berlin'));
+        $nowGermany = new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin'));
         $room = new  Rooms();
         $room->setName('test')
             ->setStart((clone $nowGermany)->modify('- 3 hours'))
@@ -73,7 +73,7 @@ class RoomCheckServiceTest extends KernelTestCase
         self::assertEquals([], $error);
 
 
-        $nowGermany = new \DateTime('now', new \DateTimeZone('Europe/Berlin'));
+        $nowGermany = new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin'));
         $room = new  Rooms();
         $room->setName('test')
             ->setStart((clone $nowGermany)->modify('- 3 hours'))
@@ -83,7 +83,7 @@ class RoomCheckServiceTest extends KernelTestCase
         $checkService->checkRoom($room, $error);
         self::assertEquals(['Fehler, das Startdatum und das Enddatum liegen in der Vergangenheit.'], $error);
 
-        $nowGermany = new \DateTime('now', new \DateTimeZone('Europe/Berlin'));
+        $nowGermany = new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin'));
         $room = new  Rooms();
         $room->setName('test')
             ->setStart((clone $nowGermany)->modify('- 8 hours'))
@@ -94,7 +94,7 @@ class RoomCheckServiceTest extends KernelTestCase
         self::assertEquals(['Fehler, das Startdatum und das Enddatum liegen in der Vergangenheit.'], $error);
 
 
-        $nowGermany = new \DateTime('now', new \DateTimeZone('Europe/Berlin'));
+        $nowGermany = new \DateTimeImmutable('now', new \DateTimeZone('Europe/Berlin'));
         $room = new  Rooms();
         $room->setName('test')
             ->setStart((clone $nowGermany)->modify('- 3 hours'))
@@ -110,8 +110,8 @@ class RoomCheckServiceTest extends KernelTestCase
     {
         $room = new Rooms();
         $room->setTimeZone('Europe/Berlin');
-        $start = new \DateTime('2026-01-15T10:00:00', new \DateTimeZone('Europe/Berlin'));
-        $end = new \DateTime('2026-01-15T11:00:00', new \DateTimeZone('Europe/Berlin'));
+        $start = new \DateTimeImmutable('2026-01-15T10:00:00', new \DateTimeZone('Europe/Berlin'));
+        $end = new \DateTimeImmutable('2026-01-15T11:00:00', new \DateTimeZone('Europe/Berlin'));
         $room->setStart($start);
         $room->setEnddate($end);
 
@@ -127,8 +127,8 @@ class RoomCheckServiceTest extends KernelTestCase
     {
         $room = new Rooms();
         $room->setTimeZone('Europe/Berlin');
-        $start = new \DateTime('2026-01-15T10:00:00', new \DateTimeZone('Europe/Berlin'));
-        $end = new \DateTime('2026-01-15T11:00:00', new \DateTimeZone('Europe/Berlin'));
+        $start = new \DateTimeImmutable('2026-01-15T10:00:00', new \DateTimeZone('Europe/Berlin'));
+        $end = new \DateTimeImmutable('2026-01-15T11:00:00', new \DateTimeZone('Europe/Berlin'));
         $room->setStart($start);
         $room->setEnddate($end);
 
@@ -145,8 +145,8 @@ class RoomCheckServiceTest extends KernelTestCase
     {
         $room = new Rooms();
         $room->setTimeZone('Europe/Berlin');
-        $start = new \DateTime('2026-01-15T10:00:00', new \DateTimeZone('Europe/Berlin'));
-        $end = new \DateTime('2026-01-15T11:00:00', new \DateTimeZone('Europe/Berlin'));
+        $start = new \DateTimeImmutable('2026-01-15T10:00:00', new \DateTimeZone('Europe/Berlin'));
+        $end = new \DateTimeImmutable('2026-01-15T11:00:00', new \DateTimeZone('Europe/Berlin'));
         $room->setStart($start);
         $room->setEnddate($end);
 
@@ -163,8 +163,8 @@ class RoomCheckServiceTest extends KernelTestCase
     {
         $room = new Rooms();
         $room->setTimeZone('Europe/Berlin');
-        $start = new \DateTime('2026-01-15T10:00:00', new \DateTimeZone('Europe/Berlin'));
-        $end = new \DateTime('2026-01-15T11:00:00', new \DateTimeZone('Europe/Berlin'));
+        $start = new \DateTimeImmutable('2026-01-15T10:00:00', new \DateTimeZone('Europe/Berlin'));
+        $end = new \DateTimeImmutable('2026-01-15T11:00:00', new \DateTimeZone('Europe/Berlin'));
         $room->setStart($start);
         $room->setEnddate($end);
 
@@ -181,13 +181,13 @@ class RoomCheckServiceTest extends KernelTestCase
     {
         $room = new Rooms();
         $room->setTimeZone('Europe/Berlin');
-        $start = new \DateTime('2026-01-15T10:00:00', new \DateTimeZone('Europe/Berlin'));
+        $start = new \DateTimeImmutable('2026-01-15T10:00:00', new \DateTimeZone('Europe/Berlin'));
         $room->setStart($start);
 
         $room->setStart(null);
         self::assertNull($room->getStartUtc());
 
-        $newStart = new \DateTime('2026-06-15T14:00:00', new \DateTimeZone('Europe/Berlin'));
+        $newStart = new \DateTimeImmutable('2026-06-15T14:00:00', new \DateTimeZone('Europe/Berlin'));
         $room->setStart($newStart);
         self::assertNotNull($room->getStartUtc());
         self::assertEquals('2026-06-15 12:00:00', $room->getStartUtc()->format('Y-m-d H:i:s'));
@@ -197,7 +197,7 @@ class RoomCheckServiceTest extends KernelTestCase
     {
         $room = new Rooms();
         $room->setTimeZone('America/New_York');
-        $start = new \DateTime('2026-12-25T09:00:00', new \DateTimeZone('America/New_York'));
+        $start = new \DateTimeImmutable('2026-12-25T09:00:00', new \DateTimeZone('America/New_York'));
         $room->setStart($start);
 
         self::assertEquals('2026-12-25 14:00:00', $room->getStartUtc()->format('Y-m-d H:i:s'));

--- a/tests/Schedule/SchedulerPublicControlerTest.php
+++ b/tests/Schedule/SchedulerPublicControlerTest.php
@@ -63,8 +63,8 @@ class SchedulerPublicControlerTest extends WebTestCase
         $umfrage = $roomRepo->findOneBy(['name' => 'Termin finden: 0']);
         self::assertEquals(5, count($umfrage->getSchedulings()[0]->getSchedulingTimes()));
         $user = $umfrage->getUser()[1];
-        $date = (new \DateTime())->modify('+10days');
-        $date->setTime(15, 00);
+        $date = (new \DateTimeImmutable())->modify('+10days');
+        $date = $date->setTime(15, 00);
         $crawler = $client->request('GET', '/scheduler/public/creator/add?user_id=' . $user->getUid() . '&room_id=' . $umfrage->getUid() . '&date=' . $date->format('Y-m-d H:i'));
         self::assertEquals(json_encode(['error' => false]), $client->getResponse()->getContent());
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
@@ -93,8 +93,8 @@ class SchedulerPublicControlerTest extends WebTestCase
         $umfrage = $roomRepo->findOneBy(['name' => 'Termin finden: 0']);
         self::assertEquals(5, count($umfrage->getSchedulings()[0]->getSchedulingTimes()));
         $user = $umfrage->getUser()[1];
-        $date = (new \DateTime())->modify('+10days');
-        $date->setTime(15, 00);
+        $date = (new \DateTimeImmutable())->modify('+10days');
+        $date = $date->setTime(15, 00);
         $crawler = $client->request('GET', '/scheduler/public/creator/add?user_id=failure' . '&room_id=' . $umfrage->getUid() . '&date=' . $date->format('Y-m-d H:i'));
         self::assertEquals(404, $client->getResponse()->getStatusCode());
     }
@@ -107,8 +107,8 @@ class SchedulerPublicControlerTest extends WebTestCase
         $umfrage = $roomRepo->findOneBy(['name' => 'Termin finden: 0']);
         self::assertEquals(5, count($umfrage->getSchedulings()[0]->getSchedulingTimes()));
         $user = $umfrage->getUser()[1];
-        $date = (new \DateTime())->modify('+10days');
-        $date->setTime(15, 00);
+        $date = (new \DateTimeImmutable())->modify('+10days');
+        $date = $date->setTime(15, 00);
         $crawler = $client->request('GET', '/scheduler/public/creator/add?user_id=' . $user->getUid() . '&room_id=failure' . '&date=' . $date->format('Y-m-d H:i'));
         self::assertEquals(404, $client->getResponse()->getStatusCode());
     }
@@ -121,8 +121,8 @@ class SchedulerPublicControlerTest extends WebTestCase
         $umfrage = $roomRepo->findOneBy(['name' => 'Termin finden: 0']);
         self::assertEquals(5, count($umfrage->getSchedulings()[0]->getSchedulingTimes()));
         $user = $umfrage->getUser()[1];
-        $date = (new \DateTime())->modify('+10days');
-        $date->setTime(15, 00);
+        $date = (new \DateTimeImmutable())->modify('+10days');
+        $date = $date->setTime(15, 00);
         $crawler = $client->request('GET', '/scheduler/public/creator/add?user_id=' . $user->getUid() . '&room_id=' . $umfrage->getUid() . '&date=' . $date->format('Y-m-dfailureH:i'));
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
         self::assertEquals(json_encode(['error' => true]), $client->getResponse()->getContent());

--- a/tests/Server/ServerActualConferenceTest.php
+++ b/tests/Server/ServerActualConferenceTest.php
@@ -36,7 +36,7 @@ class ServerActualConferenceTest extends KernelTestCase
 
         $roomPart = new RoomStatusParticipant();
         $roomPart->setInRoom(true)
-            ->setEnteredRoomAt(new \DateTime())
+            ->setEnteredRoomAt(new \DateTimeImmutable())
             ->setRoomStatus($part->getRoomStatus())
             ->setParticipantId('test123')
             ->setParticipantName('test12354');

--- a/tests/SipCaller/CallerControllerTest.php
+++ b/tests/SipCaller/CallerControllerTest.php
@@ -55,8 +55,8 @@ class CallerControllerTest extends WebTestCase
         $callerPrepareService = self::getContainer()->get(CallerPrepareService::class);
         $id = '123419';
         $room = $roomRepo->findOneBy(['name' => 'TestMeeting: 19']);
-        $room->setStart((new \DateTime())->modify('+2 hours'));
-        $room->setEnddate((new \DateTime())->modify('+4 hours'));
+        $room->setStart((new \DateTimeImmutable())->modify('+2 hours'));
+        $room->setEnddate((new \DateTimeImmutable())->modify('+4 hours'));
         $manager->persist($room);
         $manager->flush();
         $callerPrepareService->createUserCallerIDforRoom($room);
@@ -215,11 +215,11 @@ class CallerControllerTest extends WebTestCase
         $room->setLobby(true);
         $status = new RoomStatus();
         $status->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $manager->flush();
 
@@ -247,7 +247,7 @@ class CallerControllerTest extends WebTestCase
         $status = $room->getRoomstatuses()[0];
         $roomPart = new RoomStatusParticipant();
         $roomPart->setParticipantName('test12')
-            ->setEnteredRoomAt(new \DateTime())
+            ->setEnteredRoomAt(new \DateTimeImmutable())
             ->setRoomStatus($status)
             ->setInRoom(true)
             ->setParticipantId('1234');
@@ -273,7 +273,7 @@ class CallerControllerTest extends WebTestCase
 
         $roomPart = new RoomStatusParticipant();
         $roomPart->setParticipantName('test122')
-            ->setEnteredRoomAt(new \DateTime())
+            ->setEnteredRoomAt(new \DateTimeImmutable())
             ->setRoomStatus($status)
             ->setInRoom(true)
             ->setParticipantId('12345');
@@ -297,8 +297,8 @@ class CallerControllerTest extends WebTestCase
 
         $this->assertResponseIsSuccessful();
 
-        $status->setDestroyedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime())
+        $status->setDestroyedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable())
             ->setCreated(false)
             ->setDestroyed(true);
         $manager->persist($status);
@@ -334,11 +334,11 @@ class CallerControllerTest extends WebTestCase
         $room->setLobby(true);
         $status = new RoomStatus();
         $status->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $manager->flush();
 
@@ -394,11 +394,11 @@ class CallerControllerTest extends WebTestCase
         $room->setLobby(true);
         $status = new RoomStatus();
         $status->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $manager->flush();
 
@@ -463,11 +463,11 @@ class CallerControllerTest extends WebTestCase
         $room->setLobby(true);
         $status = new RoomStatus();
         $status->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $manager->flush();
 
@@ -530,11 +530,11 @@ class CallerControllerTest extends WebTestCase
         $room->setLobby(true);
         $status = new RoomStatus();
         $status->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $manager->flush();
 

--- a/tests/SipCaller/CallerIdPrepareTest.php
+++ b/tests/SipCaller/CallerIdPrepareTest.php
@@ -18,7 +18,7 @@ class CallerIdPrepareTest extends KernelTestCase
         $roomRepo = self::getContainer()->get(RoomsRepository::class);
         $room = $roomRepo->findOneBy(['name' => 'TestMeeting: 0']);
         $callerId = new CallerId();
-        $callerId->setRoom($room)->setCallerId('10')->setUser($room->getModerator())->setCreatedAt(new \DateTime());
+        $callerId->setRoom($room)->setCallerId('10')->setUser($room->getModerator())->setCreatedAt(new \DateTimeImmutable());
         $manager->persist($callerId);
         $manager->flush();
         for ($i = 0; $i < 10; $i++) {
@@ -35,7 +35,7 @@ class CallerIdPrepareTest extends KernelTestCase
         $roomRepo = self::getContainer()->get(RoomsRepository::class);
         $room = $roomRepo->findOneBy(['name' => 'TestMeeting: 0']);
         $callerId = new CallerId();
-        $callerId->setRoom($room)->setCallerId('1')->setUser($room->getModerator())->setCreatedAt(new \DateTime());
+        $callerId->setRoom($room)->setCallerId('1')->setUser($room->getModerator())->setCreatedAt(new \DateTimeImmutable());
         $manager->persist($callerId);
         $manager->flush();
 

--- a/tests/SipCaller/CallerPrepareServiceTest.php
+++ b/tests/SipCaller/CallerPrepareServiceTest.php
@@ -22,7 +22,7 @@ class CallerPrepareServiceTest extends KernelTestCase
         $callerId = new CallerRoom();
         $callerId->setRoom($room);
         $callerId->setCallerId('123456');
-        $callerId->setCreatedAt(new \DateTime());
+        $callerId->setCreatedAt(new \DateTimeImmutable());
         $manager->persist($callerId);
         $manager->flush();
         self::assertTrue($callerPrpareService->checkRandomId('123456'));
@@ -39,7 +39,7 @@ class CallerPrepareServiceTest extends KernelTestCase
         $callerId = new CallerRoom();
         $callerId->setRoom($room);
         $callerId->setCallerId('1');
-        $callerId->setCreatedAt(new \DateTime());
+        $callerId->setCreatedAt(new \DateTimeImmutable());
         $manager->persist($callerId);
         $manager->flush();
         $callerPrpareService->generateRoomId(1);
@@ -56,7 +56,7 @@ class CallerPrepareServiceTest extends KernelTestCase
         $callerId = new CallerRoom();
         $callerId->setRoom($room);
         $callerId->setCallerId('1');
-        $callerId->setCreatedAt(new \DateTime());
+        $callerId->setCreatedAt(new \DateTimeImmutable());
         $manager->persist($callerId);
         $manager->flush();
         $callerPrpareService->generateRoomId(1);

--- a/tests/SipCaller/CallerServiceTest.php
+++ b/tests/SipCaller/CallerServiceTest.php
@@ -51,8 +51,8 @@ class CallerServiceTest extends KernelTestCase
         $manager = self::getContainer()->get(EntityManagerInterface::class);
         $roomRepo = self::getContainer()->get(RoomsRepository::class);
         $room = $roomRepo->findOneBy(['name' => 'TestMeeting: 19']);
-        $room->setStart((new \DateTime())->modify('+2 hours'));
-        $room->setEnddate((new \DateTime())->modify('+4 hours'));
+        $room->setStart((new \DateTimeImmutable())->modify('+2 hours'));
+        $room->setEnddate((new \DateTimeImmutable())->modify('+4 hours'));
         $manager->persist($room);
         $manager->flush();
         self::assertEquals(['status' => 'HANGUP', 'reason' => 'TO_EARLY', 'startTime' => $room->getStartTimestamp(), 'endTime' => $room->getEndTimestamp(), 'links' => []], $callerService->findRoom($id));

--- a/tests/SipCaller/CallerSessionTest.php
+++ b/tests/SipCaller/CallerSessionTest.php
@@ -99,11 +99,11 @@ class CallerSessionTest extends KernelTestCase
         // vorbereitung
         $status = new RoomStatus();
         $status->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $manager->flush();
         $urlGen = self::getContainer()->get(UrlGeneratorInterface::class);
@@ -142,17 +142,17 @@ class CallerSessionTest extends KernelTestCase
         // vorbereitung
         $status = new RoomStatus();
         $status->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $manager->flush();
         $roomPart = new RoomStatusParticipant();
         $roomPart->setInRoom(true)
             ->setParticipantId('test@test.de')
-            ->setEnteredRoomAt(new \DateTime())
+            ->setEnteredRoomAt(new \DateTimeImmutable())
             ->setRoomStatus($status)
             ->setParticipantName('test 1234');
         $manager->persist($roomPart);
@@ -193,12 +193,12 @@ class CallerSessionTest extends KernelTestCase
         // vorbereitung
         $status = new RoomStatus();
         $status->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime())
-            ->setDestroyedAt(new \DateTime())
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable())
+            ->setDestroyedAt(new \DateTimeImmutable())
             ->setDestroyed(true);
         $manager->persist($status);
         $manager->flush();
@@ -243,11 +243,11 @@ class CallerSessionTest extends KernelTestCase
         // vorbereitung
         $status = new RoomStatus();
         $status->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $manager->flush();
         $urlGen = self::getContainer()->get(UrlGeneratorInterface::class);
@@ -265,7 +265,7 @@ class CallerSessionTest extends KernelTestCase
             ],
             $sessionService->getSessionStatus($session->getSessionId())
         );
-        $status->setDestroyedAt(new \DateTime())
+        $status->setDestroyedAt(new \DateTimeImmutable())
             ->setDestroyed(true);
         $manager->persist($status);
         $manager->flush();
@@ -596,11 +596,11 @@ class CallerSessionTest extends KernelTestCase
         $manager = self::getContainer()->get(EntityManagerInterface::class);
         $status = new RoomStatus();
         $status->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setJitsiRoomId('test')
             ->setCreated(true)
-            ->setRoomCreatedAt(new \DateTime())
-            ->setUpdatedAt(new \DateTime());
+            ->setRoomCreatedAt(new \DateTimeImmutable())
+            ->setUpdatedAt(new \DateTimeImmutable());
         $manager->persist($status);
         $manager->flush();
         self::assertEquals(
@@ -660,7 +660,7 @@ class CallerSessionTest extends KernelTestCase
         $callerSession = new CallerSession();
         $callerSession->setSessionId('test')
             ->setAuthOk(false)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setShowName('testUser');
         $waitingUser->setCallerSession($callerSession);
         $em->persist($callerSession);

--- a/tests/Star/StarControllerTest.php
+++ b/tests/Star/StarControllerTest.php
@@ -21,7 +21,7 @@ class StarControllerTest extends WebTestCase
         $starRepo = self::getContainer()->get(StarRepository::class);
         $stars = $starRepo->findAll();
         self::assertEquals(1, sizeof($stars));
-        self::assertEquals((new \DateTime())->format('d.m.YTH:i'), $stars[0]->getCreatedAt()->format('d.m.YTH:i'));
+        self::assertEquals((new \DateTimeImmutable())->format('d.m.YTH:i'), $stars[0]->getCreatedAt()->format('d.m.YTH:i'));
         self::assertEquals('windows', $stars[0]->getOs());
         self::assertEquals('opera', $stars[0]->getBrowser());
     }

--- a/tests/Statistics/StatisticServiceTest.php
+++ b/tests/Statistics/StatisticServiceTest.php
@@ -83,9 +83,9 @@ class StatisticServiceTest extends KernelTestCase
 
     private function changeStart(Rooms $rooms, $startDate)
     {
-        $rooms->setStart(new \DateTime($startDate));
+        $rooms->setStart(new \DateTimeImmutable($startDate));
         $endDate = clone $rooms->getStart();
-        $endDate->modify('+' . $rooms->getDuration() . 'min');
+        $endDate = $endDate->modify('+' . $rooms->getDuration() . 'min');
         $rooms->setEnddate($endDate);
         return $rooms;
     }

--- a/tests/Unit/Controller/ScheduleControllerControllerTest.php
+++ b/tests/Unit/Controller/ScheduleControllerControllerTest.php
@@ -9,7 +9,7 @@ use App\Entity\SchedulingTime;
 use App\Entity\SchedulingTimeUser;
 use App\Entity\User;
 use App\Service\SchedulingService;
-use DateTime;
+use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -80,7 +80,7 @@ class ScheduleControllerControllerTest extends WebTestCase
         $room = $this->getRoomMock();
         $scheduling = $this->getSchedulingMock();
         $schedulingTime = $this->getSchedulingTimeMock();
-        $dateTime = new DateTime();
+        $dateTime = new DateTimeImmutable();
 
         $schedulingCollection = new ArrayCollection();
         $schedulingCollection->add($scheduling);

--- a/tests/Unit/Controller/ScheduleControllerTest.php
+++ b/tests/Unit/Controller/ScheduleControllerTest.php
@@ -9,7 +9,7 @@ use App\Entity\SchedulingTime;
 use App\Entity\SchedulingTimeUser;
 use App\Entity\User;
 use App\Service\SchedulingService;
-use DateTime;
+use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -94,7 +94,7 @@ class ScheduleControllerTest extends KernelTestCase
         $schedulingTimeUserCollection2->add($schedulingTimeUser2);
         $schedulingTimeUserCollection2->add($schedulingTimeUser3);
 
-        $dateTime1 = new DateTime('2023-10-31');
+        $dateTime1 = new DateTimeImmutable('2023-10-31');
         $dateTime2 = (clone $dateTime1)->modify('+1 day');
 
         $room

--- a/tests/Utils/UtilsHelperTest.php
+++ b/tests/Utils/UtilsHelperTest.php
@@ -21,7 +21,7 @@ class UtilsHelperTest extends KernelTestCase
         $depElement1 = new Deputy();
         $depElement1->setManager($manager)
             ->setDeputy($deputy)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setIsFromLdap(false);
         $manager->addManagerElement($depElement1);
         $deputy->addDeputiesElement($depElement1);
@@ -57,7 +57,7 @@ class UtilsHelperTest extends KernelTestCase
         $depElement2 = new Deputy();
         $depElement2->setManager($manager)
             ->setDeputy($deputy2)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setIsFromLdap(false);
         $manager->addManagerElement($depElement2);
         $deputy2->addDeputiesElement($depElement2);
@@ -92,7 +92,7 @@ class UtilsHelperTest extends KernelTestCase
         $depElement1 = new Deputy();
         $depElement1->setManager($manager)
             ->setDeputy($deputy)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setIsFromLdap(false);
         $manager->addManagerElement($depElement1);
         $deputy->addDeputiesElement($depElement1);
@@ -107,7 +107,7 @@ class UtilsHelperTest extends KernelTestCase
         $depElement2 = new Deputy();
         $depElement2->setManager($manager)
             ->setDeputy($deputy2)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setIsFromLdap(false);
         $manager->addManagerElement($depElement2);
         $deputy2->addDeputiesElement($depElement2);

--- a/tests/Whiteboard/WhiteBoardJwtServiceTest.php
+++ b/tests/Whiteboard/WhiteBoardJwtServiceTest.php
@@ -19,8 +19,8 @@ class WhiteBoardJwtServiceTest extends KernelTestCase
         self::assertEquals(
             JWT::encode(
                 [
-                    'iat' => (new \DateTime())->getTimestamp(),
-                    'exp' => (new \DateTime())->modify('+3days')->getTimestamp(),
+                    'iat' => (new \DateTimeImmutable())->getTimestamp(),
+                    'exp' => (new \DateTimeImmutable())->modify('+3days')->getTimestamp(),
                     'roles' => ['editor:' . $room->getUidReal()]
                 ],
                 'MY_SECRET',
@@ -31,8 +31,8 @@ class WhiteBoardJwtServiceTest extends KernelTestCase
         self::assertEquals(
             JWT::encode(
                 [
-                    'iat' => (new \DateTime())->getTimestamp(),
-                    'exp' => (new \DateTime())->modify('+3days')->getTimestamp(),
+                    'iat' => (new \DateTimeImmutable())->getTimestamp(),
+                    'exp' => (new \DateTimeImmutable())->modify('+3days')->getTimestamp(),
                     'roles' => ['moderator:' . $room->getUidReal()]
                 ],
                 'MY_SECRET',

--- a/tests/callOut/CalloutAPIBackServiceTest.php
+++ b/tests/callOut/CalloutAPIBackServiceTest.php
@@ -27,14 +27,14 @@ class CalloutAPIBackServiceTest extends KernelTestCase
         $calloutSession1 = new CalloutSession();
         $calloutSession1->setUser($user)
             ->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setInvitedFrom($room->getModerator())
             ->setState(0)
             ->setUid('ksdlfjlkfds')
             ->setLeftRetries(2);
         $manager->persist($calloutSession1);
         $callerUserId = new CallerId();
-        $callerUserId->setCreatedAt(new \DateTime())
+        $callerUserId->setCreatedAt(new \DateTimeImmutable())
             ->setRoom($room)
             ->setUser($user)
             ->setCallerId('987654321');

--- a/tests/callOut/CalloutAPIDialServiceTest.php
+++ b/tests/callOut/CalloutAPIDialServiceTest.php
@@ -26,14 +26,14 @@ class CalloutAPIDialServiceTest extends KernelTestCase
         $calloutSession1 = new CalloutSession();
         $calloutSession1->setUser($user)
             ->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setInvitedFrom($room->getModerator())
             ->setState(0)
             ->setUid('ksdlfjlkfds')
             ->setLeftRetries(2);
         $manager->persist($calloutSession1);
         $callerUserId = new CallerId();
-        $callerUserId->setCreatedAt(new \DateTime())
+        $callerUserId->setCreatedAt(new \DateTimeImmutable())
             ->setRoom($room)
             ->setUser($user)
             ->setCallerId('987654321');

--- a/tests/callOut/CalloutAPIRemoveServiceFromRingingTest.php
+++ b/tests/callOut/CalloutAPIRemoveServiceFromRingingTest.php
@@ -28,14 +28,14 @@ class CalloutAPIRemoveServiceFromRingingTest extends KernelTestCase
         $calloutSession1 = new CalloutSession();
         $calloutSession1->setUser($user)
             ->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setInvitedFrom($room->getModerator())
             ->setState(CalloutSession::$RINGING)
             ->setUid('ksdlfjlkfds')
             ->setLeftRetries(2);
         $manager->persist($calloutSession1);
         $callerUserId = new CallerId();
-        $callerUserId->setCreatedAt(new \DateTime())
+        $callerUserId->setCreatedAt(new \DateTimeImmutable())
             ->setRoom($room)
             ->setUser($user)
             ->setCallerId('987654321');

--- a/tests/callOut/CalloutAPIRemoveServiceTest.php
+++ b/tests/callOut/CalloutAPIRemoveServiceTest.php
@@ -28,14 +28,14 @@ class CalloutAPIRemoveServiceTest extends KernelTestCase
         $calloutSession1 = new CalloutSession();
         $calloutSession1->setUser($user)
             ->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setInvitedFrom($room->getModerator())
             ->setState(CalloutSession::$DIALED)
             ->setUid('ksdlfjlkfds')
             ->setLeftRetries(2);
         $manager->persist($calloutSession1);
         $callerUserId = new CallerId();
-        $callerUserId->setCreatedAt(new \DateTime())
+        $callerUserId->setCreatedAt(new \DateTimeImmutable())
             ->setRoom($room)
             ->setUser($user)
             ->setCallerId('987654321');

--- a/tests/callOut/CalloutApiActionControllerTest.php
+++ b/tests/callOut/CalloutApiActionControllerTest.php
@@ -34,7 +34,7 @@ class CalloutApiActionControllerTest extends WebTestCase
         $moderator = $userRepo->findOneBy(['email' => 'test@local.de']);
         $this->client->loginUser($moderator);
         $callerUserId = new CallerId();
-        $callerUserId->setCreatedAt(new \DateTime())
+        $callerUserId->setCreatedAt(new \DateTimeImmutable())
             ->setRoom($this->room)
             ->setUser($user)
             ->setCallerId('987654321');

--- a/tests/callOut/CalloutApiActionControllerUnauthorizedTest.php
+++ b/tests/callOut/CalloutApiActionControllerUnauthorizedTest.php
@@ -32,14 +32,14 @@ class CalloutApiActionControllerUnauthorizedTest extends WebTestCase
         $calloutSession1 = new CalloutSession();
         $calloutSession1->setUser($user)
             ->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setInvitedFrom($room->getModerator())
             ->setState(1)
             ->setUid('ksdlfjlkfds')
             ->setLeftRetries(2);
         $manager->persist($calloutSession1);
         $callerUserId = new CallerId();
-        $callerUserId->setCreatedAt(new \DateTime())
+        $callerUserId->setCreatedAt(new \DateTimeImmutable())
             ->setRoom($room)
             ->setUser($user)
             ->setCallerId('987654321');

--- a/tests/callOut/CalloutApiPoolTest.php
+++ b/tests/callOut/CalloutApiPoolTest.php
@@ -24,7 +24,7 @@ class CalloutApiPoolTest extends KernelTestCase
         $calloutSession1 = new CalloutSession();
         $calloutSession1->setUser($user)
             ->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setInvitedFrom($room->getModerator())
             ->setState(0)
             ->setUid('ksdlfjlkfds')
@@ -33,7 +33,7 @@ class CalloutApiPoolTest extends KernelTestCase
         $calloutSession2 = new CalloutSession();
         $calloutSession2->setUser($user)
             ->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setInvitedFrom($room->getModerator())
             ->setState(10)
             ->setUid('ksdlfjlkfdfgsdds')
@@ -42,14 +42,14 @@ class CalloutApiPoolTest extends KernelTestCase
         $calloutSession3 = new CalloutSession();
         $calloutSession3->setUser($user)
             ->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setInvitedFrom($room->getModerator())
             ->setState(20)
             ->setUid('ksddfglfjlkfds')
             ->setLeftRetries(2);
         $manager->persist($calloutSession3);
         $callerUserId = new CallerId();
-        $callerUserId->setCreatedAt(new \DateTime())
+        $callerUserId->setCreatedAt(new \DateTimeImmutable())
             ->setRoom($room)
             ->setUser($user)
             ->setCallerId('987654321');

--- a/tests/callOut/CalloutHoldApiFromRingingServiceTest.php
+++ b/tests/callOut/CalloutHoldApiFromRingingServiceTest.php
@@ -30,14 +30,14 @@ class CalloutHoldApiFromRingingServiceTest extends KernelTestCase
         $calloutSession1 = new CalloutSession();
         $calloutSession1->setUser($user)
             ->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setInvitedFrom($room->getModerator())
             ->setState(15)
             ->setUid('ksdlfjlkfds')
             ->setLeftRetries(2);
         $manager->persist($calloutSession1);
         $callerUserId = new CallerId();
-        $callerUserId->setCreatedAt(new \DateTime())
+        $callerUserId->setCreatedAt(new \DateTimeImmutable())
             ->setRoom($room)
             ->setUser($user)
             ->setCallerId('987654321');

--- a/tests/callOut/CalloutHoldApiServiceTest.php
+++ b/tests/callOut/CalloutHoldApiServiceTest.php
@@ -30,14 +30,14 @@ class CalloutHoldApiServiceTest extends KernelTestCase
         $calloutSession1 = new CalloutSession();
         $calloutSession1->setUser($user)
             ->setRoom($room)
-            ->setCreatedAt(new \DateTime())
+            ->setCreatedAt(new \DateTimeImmutable())
             ->setInvitedFrom($room->getModerator())
             ->setState(10)
             ->setUid('ksdlfjlkfds')
             ->setLeftRetries(2);
         $manager->persist($calloutSession1);
         $callerUserId = new CallerId();
-        $callerUserId->setCreatedAt(new \DateTime())
+        $callerUserId->setCreatedAt(new \DateTimeImmutable())
             ->setRoom($room)
             ->setUser($user)
             ->setCallerId('987654321');

--- a/tests/callOut/CalloutServiceTest.php
+++ b/tests/callOut/CalloutServiceTest.php
@@ -226,7 +226,7 @@ class CalloutServiceTest extends KernelTestCase
         $callerId->setUser($user)
         ->setRoom($room)
        ->setCallerId('test')
-            ->setCreatedAt(new \DateTime());
+            ->setCreatedAt(new \DateTimeImmutable());
         $manager->persist($callerId);
         $manager->flush();
         $callerSession = new CallerSession();
@@ -234,7 +234,7 @@ class CalloutServiceTest extends KernelTestCase
             ->setCallerId('test123')
             ->setSessionId('test1234')
             ->setAuthOk(true)
-            ->setCreatedAt(new \DateTime());
+            ->setCreatedAt(new \DateTimeImmutable());
         $manager->persist($callerSession);
         $manager->flush();
         self::assertEquals(0, sizeof($callOurRepo->findAll()));


### PR DESCRIPTION
## Summary

1) Converted DateTime to DateTimeImmutable to avoid sneaky date modification bugs
2) Switched hardcoded repeat function integers to Enums
3) Added new tests for repeat functionality

